### PR TITLE
adding ability to force draw os cursor

### DIFF
--- a/include/radix/env/ArgumentsParser.hpp
+++ b/include/radix/env/ArgumentsParser.hpp
@@ -9,6 +9,7 @@ class ArgumentsParser {
 private:
   static std::string mapName;
   static std::string mapPath;
+  static bool showCursor;
 public:
   static void showUsage(char **argv);
   static void setEnvironmentFromArgs(const int argc, char **argv);

--- a/include/radix/env/Config.hpp
+++ b/include/radix/env/Config.hpp
@@ -17,9 +17,10 @@ public:
   bool hasSound() { return sound; }
   bool hasVsync() { return vsync; }
   bool isHidePortalsByClick() { return hide_portals_by_click; }
-
+  
   std::string map;
   std::string mapPath;
+  bool cursorVisibility;
 private:
   unsigned int width;
   unsigned int height;

--- a/source/Window.cpp
+++ b/source/Window.cpp
@@ -175,6 +175,7 @@ void Window::lockMouse() {
 }
 
 void Window::unlockMouse() {
+  SDL_WarpMouseInWindow(window, width / 2, height / 2);
   SDL_SetRelativeMouseMode(SDL_FALSE);
 }
 

--- a/source/env/ArgumentsParser.cpp
+++ b/source/env/ArgumentsParser.cpp
@@ -13,6 +13,7 @@
 namespace radix {
 std::string ArgumentsParser::mapName = "";
 std::string ArgumentsParser::mapPath = "";
+bool ArgumentsParser::showCursor = false;
 
 void ArgumentsParser::showUsage(char **argv) {
   std::cout << "Usage: " << argv[0]  << " [options]" << std::endl << std::endl;
@@ -23,12 +24,14 @@ void ArgumentsParser::showUsage(char **argv) {
   std::cout << "  -d, --datadir DIR        Set the data directory" << std::endl;
   std::cout << "  -m, --map NAME           Specify map name to load" << std::endl;
   std::cout << "  -M, --mapfrompath FILE   Load the specified map file" << std::endl;
+  std::cout << "  -c, --showcursor         Forces to draw os mouse cursor" << std::endl;
 }
 
 void ArgumentsParser::setEnvironmentFromArgs(const int argc, char **argv) {
   static struct option long_options[] = {
     {"version",          no_argument,       0, 'v'},
     {"help",             no_argument,       0, 'h'},
+    {"showcursor",       no_argument, 	    0, 'c'},
     {"datadir",          required_argument, 0, 'd'},
     {"map",              required_argument, 0, 'm'},
     {"mapfrompath",      required_argument, 0, 'M'},
@@ -71,6 +74,12 @@ void ArgumentsParser::setEnvironmentFromArgs(const int argc, char **argv) {
       /// Set the map that should be loaded.
       mapPath = optarg;
       break;
+    case 'c':
+      /// - showCursor \n
+      /// Forces os mouse cursor to be drawn
+      /// Defaults to false;
+      showCursor = true;
+      break;
     case '?':
       /// getopt error handling
 	  /// getopt has already shown an error message.
@@ -90,6 +99,8 @@ void ArgumentsParser::populateConfig() {
   if (not mapPath.empty()) {
     config.mapPath = mapPath;
   }
+  
+  config.cursorVisibility = showCursor;
 }
 
 } /* namespace radix */


### PR DESCRIPTION
The ability to draw the os cursor was already available as a part of `window` class, I have added relevant properties to the config and exposed it so that we can enable/disable this feature through argument flag.

This can be useful while debugging the game, and fixes the issue _(that so far only I must have had)_ where cursor would be invisible in KDevelop IDE when hitting a breakpoint while the game is in the background.