### PR TITLE
Fix ambiguity error for logging List size.

### DIFF
--- a/include/radix/core/diag/LogInput.hpp
+++ b/include/radix/core/diag/LogInput.hpp
@@ -46,6 +46,7 @@ public:
   LogInput& operator<<(int32_t);
   LogInput& operator<<(uint64_t);
   LogInput& operator<<(int64_t);
+  LogInput& operator<<(unsigned long);
   LogInput& operator<<(float);
   LogInput& operator<<(double);
   LogInput& operator<<(const void*);

--- a/source/core/diag/LogInput.cpp
+++ b/source/core/diag/LogInput.cpp
@@ -95,6 +95,11 @@ LogInput& LogInput::operator<<(int64_t i) {
   return *this;
 }
 
+LogInput& LogInput::operator<<(long unsigned l) {
+  buf.append(std::to_string(l));
+  return *this;
+}
+
 LogInput& LogInput::operator<<(float f) {
   buf.append(std::to_string(f));
   return *this;


### PR DESCRIPTION
I just added a function definition for directly handling unsigned long. This solved the issue of ambiguous function call as it no longer has to type cast. 