### PR TITLE
Templating Numbers

### DIFF
--- a/include/radix/core/diag/LogInput.hpp
+++ b/include/radix/core/diag/LogInput.hpp
@@ -38,14 +38,8 @@ public:
 
   LogInput& operator<<(bool);
   LogInput& operator<<(char);
-  LogInput& operator<<(uint8_t);
-  LogInput& operator<<(int8_t);
-  LogInput& operator<<(uint16_t);
-  LogInput& operator<<(int16_t);
-  LogInput& operator<<(uint32_t);
-  LogInput& operator<<(int32_t);
-  LogInput& operator<<(uint64_t);
-  LogInput& operator<<(int64_t);
+  template <typename N>
+  LogInput& operator<<(N number);
   LogInput& operator<<(unsigned long);
   LogInput& operator<<(float);
   LogInput& operator<<(double);

--- a/source/core/diag/LogInput.cpp
+++ b/source/core/diag/LogInput.cpp
@@ -55,58 +55,9 @@ LogInput& LogInput::operator<<(char c) {
   return *this;
 }
 
-LogInput& LogInput::operator<<(uint8_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(int8_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(uint16_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(int16_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(uint32_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(int32_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(uint64_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(int64_t i) {
-  buf.append(std::to_string(i));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(long unsigned l) {
-  buf.append(std::to_string(l));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(float f) {
-  buf.append(std::to_string(f));
-  return *this;
-}
-
-LogInput& LogInput::operator<<(double f) {
-  buf.append(std::to_string(f));
+template <typename N>
+LogInput & LogInput::operator<<(N number) {
+  buf.append(std::to_string(number));
   return *this;
 }
 


### PR DESCRIPTION
The overriding of multiple number types should be left to the compiler to consider when the compiler needs it. This will prevent from ambiguity errors, and it shortens the code, because we only need to write one function for all number types (or anything that can be converted to string using the std::to_string method). 

