### PR TITLE
Implement self-closing screens

### DIFF
--- a/include/radix/GameWorld.hpp
+++ b/include/radix/GameWorld.hpp
@@ -1,7 +1,7 @@
 #ifndef RADIX_GAME_WORLD_HPP
 #define RADIX_GAME_WORLD_HPP
 
-#include <list>
+#include <map>
 #include <radix/input/InputSource.hpp>
 #include <radix/data/screen/Screen.hpp>
 
@@ -11,10 +11,10 @@ class GameWorld {
 public:
   InputSource &input;
   GameWorld(InputSource &input);
-  void addScreen(Screen& screen);
-  std::list<Screen*>* getScreens();
+  void addScreen(Screen &screen);
+  std::list<Screen>* getScreens();
 private:
-  std::list<Screen*> screens;
+  std::list<Screen> screens;
 };
 
 } /* namespace radix */

--- a/include/radix/data/screen/Screen.hpp
+++ b/include/radix/data/screen/Screen.hpp
@@ -3,16 +3,36 @@
 
 #include <vector>
 
+#include <radix/World.hpp>
 #include <radix/data/text/Text.hpp>
 #include <radix/data/screen/Element.hpp>
 #include <radix/core/math/Vector4f.hpp>
+#include <radix/core/event/EventDispatcher.hpp>
 
 namespace radix {
 
+struct ScreenConstructor;
+
 struct Screen {
+  Screen(World &world, const ScreenConstructor &constructor);
   Vector4f color;
   std::vector<Text> text;
   std::vector<Element> elements;
+  
+  /* closing */
+  World &world;
+  std::string key;
+  bool remove = false;
+  EventDispatcher::CallbackHolder keyPressedHolder;
+};
+
+struct ScreenConstructor {
+  Vector4f color;
+  std::vector<Text> text;
+  std::vector<Element> elements;
+  
+  /* closing */
+  std::string key;
 };
 
 } /* namespace radix */

--- a/include/radix/data/screen/XmlScreenLoader.hpp
+++ b/include/radix/data/screen/XmlScreenLoader.hpp
@@ -11,14 +11,17 @@
 
 namespace radix {
 
+class World;
+  
 class XmlScreenLoader : public XmlLoader {
 public:
-  static Screen& getScreen(const std::string& path);
+  static Screen& getScreen(World &world, const std::string& path);
 private:
-  static std::map<std::string, std::shared_ptr<Screen>> screenCache;
-  static std::shared_ptr<Screen> loadScreen(const std::string& path);
+  static ScreenConstructor loadConstructor (const std::string& path);
+  static std::shared_ptr<Screen> construct(World &world, const ScreenConstructor &constructor);
   static const std::string MODULE_NAME;
   static bool loadText(tinyxml2::XMLHandle &rootHandle, std::vector<Text>* text);
+  static std::map<std::string, ScreenConstructor> screenCache;
 };
 
 } /* namespace radix */

--- a/include/radix/data/text/Font.hpp
+++ b/include/radix/data/text/Font.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 
+#include <radix/env/Util.hpp>
 #include <radix/data/text/Glyph.hpp>
 
 namespace radix {
@@ -21,6 +22,7 @@ public:
     int length = 0;
     const char *array = string.c_str();
     for (unsigned int i = 0; i < string.length(); i++) {
+      Util::Log(Debug, "Font") << array[i];
       const Glyph &letter = getGlyph(array[i]);
       length += letter.width * this->size;
     }

--- a/include/radix/renderer/ScreenRenderer.hpp
+++ b/include/radix/renderer/ScreenRenderer.hpp
@@ -11,14 +11,14 @@
 
 namespace radix {
 
-class ScreenRenderer : public SubRenderer{
+class ScreenRenderer : public SubRenderer {
 public:
   ScreenRenderer(World& w, Renderer& ren, GameWorld& gw);
 
   void render();
 
 private:
-  void renderScreen(Screen* screen);
+  void renderScreen(Screen &screen);
 
   GameWorld &gameWorld;
 };

--- a/include/radix/util/KeyDecoder.hpp
+++ b/include/radix/util/KeyDecoder.hpp
@@ -1,0 +1,17 @@
+#ifndef RADIX_KEY_DECODER_HPP
+#define RADIX_KEY_DECODER_HPP
+
+#include <map>
+
+namespace radix {
+    
+class KeyDecoder {
+public:
+    static int decodeString(const std::string &keyString);
+private:
+    static const std::map<std::string, int> lookupTable;
+};
+    
+} /* namespace radix */
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -60,6 +60,7 @@ set(RADIX_SOURCES
   ${D}/data/model/MeshLoader.cpp
   ${D}/data/text/FontLoader.cpp
   ${D}/data/texture/TextureLoader.cpp
+  ${D}/data/screen/Screen.cpp
   ${D}/data/screen/XmlScreenLoader.cpp
   ${D}/data/screen/Element.cpp
   ${D}/data/shader/Shader.cpp
@@ -83,6 +84,7 @@ set(RADIX_SOURCES
   ${D}/util/sdl/Fps.cpp
   ${D}/util/NullReference.cpp
   ${D}/util/XmlLoader.cpp
+  ${D}/util/KeyDecoder.cpp
   ${D}/Window.cpp
   ${D}/World.cpp
   PARENT_SCOPE

--- a/source/GameWorld.cpp
+++ b/source/GameWorld.cpp
@@ -6,10 +6,11 @@ GameWorld::GameWorld(InputSource &input) :
 }
 
 void GameWorld::addScreen(Screen &screen) {
-  screens.push_back(&screen);
+  screens.push_back(std::move(screen));
 }
 
-std::list<Screen*>* GameWorld::getScreens() {
+std::list<Screen>* GameWorld::getScreens()
+{
   return &screens;
 }
 } /* namespace radix */

--- a/source/data/screen/Screen.cpp
+++ b/source/data/screen/Screen.cpp
@@ -1,0 +1,26 @@
+#include <radix/data/screen/Screen.hpp>
+
+#include <radix/World.hpp>
+#include <radix/util/KeyDecoder.hpp>
+
+namespace radix {
+  
+Screen::Screen(World &world, const ScreenConstructor &constructor) :
+  color(constructor.color),
+  text(constructor.text),
+  elements(constructor.elements),
+  world(world),
+  key(constructor.key) {
+    keyPressedHolder = world.event.addObserver(
+      radix::InputSource::KeyReleasedEvent::Type, [this] (const radix::Event& event) {
+      const int keyCode = ((radix::InputSource::KeyReleasedEvent &) event).key;
+      if (key.empty()) {
+        return;
+      }
+      if (keyCode == KeyDecoder::decodeString(key)) {
+         remove = true;
+      }
+  });
+}
+  
+} /* namespace radix */

--- a/source/renderer/ScreenRenderer.cpp
+++ b/source/renderer/ScreenRenderer.cpp
@@ -15,12 +15,12 @@ ScreenRenderer::ScreenRenderer(World &w, Renderer &ren, GameWorld &gw) :
   gameWorld(gw) { }
 
 void ScreenRenderer::render() {
-  for (Screen *screen : *gameWorld.getScreens()) {
+  for (Screen &screen : *gameWorld.getScreens()) {
     renderScreen(screen);
   }
 }
 
-void ScreenRenderer::renderScreen(Screen *screen) {
+void ScreenRenderer::renderScreen(Screen &screen) {
   PROFILER_BLOCK("ScreenRenderer::renderScreen", profiler::colors::LightGreen100);
   glDepthMask(GL_FALSE);
 
@@ -38,20 +38,21 @@ void ScreenRenderer::renderScreen(Screen *screen) {
   Shader &shader = ShaderLoader::getShader("color.frag");
 
   shader.bind();
-  glUniform4f(shader.uni("color"), screen->color.r, screen->color.g, screen->color.b, screen->color.a);
+  glUniform4f(shader.uni("color"), screen.color.r, screen.color.g, screen.color.b, screen.color.a);
   renderer.renderMesh(*renderContext, shader, widget, mesh);
 
   shader.release();
 
-  for (unsigned int i = 0; i < screen->text.size(); i++) {
-    screen->text[i].font = "Pacaya";
-    Font font = FontLoader::getFont(screen->text[i].font);
-    font.size = screen->text[i].size;
-    int textWidth = font.getStringLength(screen->text[i].content);
-    Vector3f position(0, 0, screen->text[i].z);
+  for (unsigned int i = 0; i < screen.text.size(); i++) {
+    screen.text[i].font = "Pacaya";
+    Util::Log(Debug, "ScreenRenderer") << screen.text[i].content << " " << i;
+    Font font = FontLoader::getFont(screen.text[i].font);
+    font.size = screen.text[i].size;
+    int textWidth = font.getStringLength(screen.text[i].content);
+    Vector3f position(0, 0, screen.text[i].z);
 
-    position.y = viewportHeight - screen->text[i].top;
-    Text::Align textAlign = screen->text[i].align;
+    position.y = viewportHeight - screen.text[i].top;
+    Text::Align textAlign = screen.text[i].align;
     if (textAlign == Text::Center) {
       position.x = xAxisViewportCenter - (textWidth / 2);
     } else if (textAlign == Text::Left) {
@@ -60,9 +61,9 @@ void ScreenRenderer::renderScreen(Screen *screen) {
       position.x = (xAxisViewportCenter + viewportWidth / 4) - (textWidth / 2);
     }
 
-    screen->text[i].position = position;
+    screen.text[i].position = position;
 
-    renderer.renderText(*renderContext, screen->text[i]);
+    renderer.renderText(*renderContext, screen.text[i]);
   }
 
   glDepthMask(GL_TRUE);

--- a/source/util/KeyDecoder.cpp
+++ b/source/util/KeyDecoder.cpp
@@ -1,0 +1,21 @@
+#include <radix/util/KeyDecoder.hpp>
+
+#include <SDL_scancode.h>
+
+namespace radix {
+  
+const std::map<std::string, int> KeyDecoder::lookupTable = { 
+  {"escape", SDL_SCANCODE_ESCAPE},
+  {"return", SDL_SCANCODE_RETURN},
+  {"space", SDL_SCANCODE_SPACE},
+  {"up", SDL_SCANCODE_UP},
+  {"down", SDL_SCANCODE_DOWN},
+  {"left", SDL_SCANCODE_LEFT},
+  {"right", SDL_SCANCODE_RIGHT},
+};
+
+int KeyDecoder::decodeString(const std::string &keyString) {
+  return lookupTable.find(keyString)->second;
+}
+
+} /* namespace radix */


### PR DESCRIPTION
# This commit adds the following:
	- Adds an observer to Screen
	- A key decoder class
	- Screen constructors (holds to bare values used to construct a
screen such as text and colours)

# What doesn't work:

Displaying the screen currently does not work. When using gdb and
breakpointing at places screens get accessed, the text values slowly
seem to corrupt. This can be observed by setting breakpoints in
ScreenRenderer and Font. I have included debug messages to show my
progress in chasing down the bug.

Signed-off-by: Geert Custers <geert.aj.custers@gmail.com>