### PR TITLE
Fix forward declaration for struct Screen

### DIFF
--- a/include/radix/GameWorld.hpp
+++ b/include/radix/GameWorld.hpp
@@ -6,7 +6,7 @@
 namespace radix {
 
 class InputSource;
-class Screen;
+struct Screen;
 
 class GameWorld {
 public:


### PR DESCRIPTION
This made it unlinkable duo to different signature