### PR TITLE
Update freeimage dependency to latest apt package

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -50,7 +50,7 @@ pacman -S cmake make gcc pkg-config assimp libepoxy sdl2 sdl2_mixer bullet mesa 
 
 ### Debian 8 / Ubuntu 14.04 / Linux Mint 17.x
 ```bash
-apt-get install cmake make gcc pkg-config lib{assimp,epoxy,sdl2,sdl2-mixer,bullet,tinyxml2,gl1-mesa,unittest++,freeimage}-dev
+apt-get install cmake make gcc pkg-config lib{assimp,epoxy,sdl2,sdl2-mixer,bullet,tinyxml2,gl1-mesa,unittest++,freeimageplus}-dev
 ```
 
 ### Others

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -48,7 +48,7 @@ pacman -S git
 pacman -S cmake make gcc pkg-config assimp libepoxy sdl2 sdl2_mixer bullet mesa unittestpp freeimage
 ```
 
-### Debian 8 / Ubuntu 14.04 / Linux Mint 17.x
+### Debian 9 / Ubuntu 16.04 / Linux Mint 18.x
 ```bash
 apt-get install cmake make gcc pkg-config lib{assimp,epoxy,sdl2,sdl2-mixer,bullet,tinyxml2,gl1-mesa,unittest++,freeimageplus}-dev
 ```


### PR DESCRIPTION
Small change to build docs to use the correct freeimage package on Ubuntu. Haven't tested on arch or other systems, so this may apply to arch as well.