### PR TITLE
Input System

### DIFF
--- a/include/radix/BaseGame.hpp
+++ b/include/radix/BaseGame.hpp
@@ -11,6 +11,15 @@
 #include <radix/util/sdl/Fps.hpp>
 #include <radix/GameWorld.hpp>
 #include <radix/Window.hpp>
+#include <radix/renderer/Renderer.hpp>
+#include <radix/renderer/ScreenRenderer.hpp>
+#include <radix/core/event/EventDispatcher.hpp>
+#include <radix/data/map/XmlMapLoader.hpp>
+#include <radix/data/map/CustomTrigger.hpp>
+#include <radix/data/screen/Screen.hpp>
+#include <radix/renderer/ScreenRenderer.hpp>
+#include <radix/env/Config.hpp>
+#include <radix/input/InputManager.hpp>
 
 namespace radix {
 
@@ -60,6 +69,10 @@ public:
   void deferPostCycle(const std::function<void()>&);
 
   World* getWorld();
+  Config& getConfig();
+  inline InputManager& getInputManager() {
+    return inputManager;
+  }
 
   template<class T, typename... Args>
   T& createOtherWorld(const std::string &name, Args&&... args) {
@@ -91,10 +104,10 @@ protected:
   void loadMap(World&);
   virtual void prepareCamera();
   virtual void initHook();
-  virtual void removeHook();
   virtual void customTriggerHook();
 
   Window window;
+  InputManager inputManager;
   std::map<std::string, std::unique_ptr<World>> otherWorlds;
   std::unique_ptr<World> world;
   Config config;

--- a/include/radix/BaseGame.hpp
+++ b/include/radix/BaseGame.hpp
@@ -104,6 +104,7 @@ protected:
   void loadMap(World&);
   virtual void prepareCamera();
   virtual void initHook();
+  virtual void removeHook();
   virtual void customTriggerHook();
 
   Window window;

--- a/include/radix/Window.hpp
+++ b/include/radix/Window.hpp
@@ -7,9 +7,9 @@
 
 #include <SDL2/SDL_video.h>
 
+#include <radix/env/Config.hpp>
 #include <radix/input/InputSource.hpp>
 #include <radix/Viewport.hpp>
-#include <radix/env/Config.hpp>
 #include <radix/core/math/Vector2i.hpp>
 
 namespace radix {
@@ -90,22 +90,72 @@ public:
    * @param key input keyboard type
    * @param mod input keyboard mode
    */
-  void keyPressed(KeyboardKey key, KeyboardModifier mod) override;
+  void keyPressed(const KeyboardKey &key, const KeyboardModifier &mod) override;
 
   /**
    * @brief keyReleased handle released keyboard input
    * @param key input keyboard type
    * @param mod input keyboard modifier
    */
-  void keyReleased(KeyboardKey key, KeyboardModifier mod) override;
+  void keyReleased(const KeyboardKey &key, const KeyboardModifier &mod) override;
 
   /**
    * @brief isKeyDown check keyboard status
    * @param key input keyboard type
    * @return if key is pressed
    */
-  bool isKeyDown(KeyboardKey key) override;
+  bool isKeyDown(const KeyboardKey &key) override;
   /**@} */
+
+  /**
+    * @name controller methods
+    *@{ */
+  /**
+   * @brief controllerButtonPressed handle pressed controller button input
+   * @param button input button type
+   */
+  void controllerButtonPressed(const ControllerButton &button, const ControllerIndex &index) override;
+
+  /**
+   * @brief controllerButtonPressed handle released controller button input
+   * @param button input button type
+   */
+  void controllerButtonReleased(const ControllerButton &button, const ControllerIndex &index) override;
+
+  /**
+   * @brief controllerButtonPressed check controller button status
+   * @param button input button type
+   * @return if button is depressed
+   */
+  bool isControllerButtonDown(const ControllerButton &button, const ControllerIndex &index) override;
+
+  /**
+   * @brief getControllerAxisValue check controller axis value
+   * @param axis axis index
+   * @param index controller index
+   */
+  float getControllerAxisValue(const ControllerAxis &axis, const ControllerIndex &index) override;
+  /**@} */
+
+  /**
+   * @brief controllerButtonPressed check mouse button status
+   * @param button input button type
+   * @return if button is depressed
+   */
+  bool isMouseButtonDown(const int &button) override;
+
+  /**
+   * @brief getMouseAxisValue get mouse axis value
+   * @param axis x or y
+   */
+  float getRelativeMouseAxisValue(const int &axis) override;
+
+  /**
+   * @brief getRelativeMouseState track mouse movement
+   * @param dx mouse x movement
+   * @param dy mouse y movement
+   */
+  void getRelativeMouseState(int *dx, int *dy) override;
 
   /**
    * @name CharBuffer methods
@@ -168,19 +218,25 @@ private:
    */
   void setSdlGlAttributes();
 
+  void processMouseAxisEvents();
+
+  void processControllerStickEvents();
+
+  void processControllerTriggerEvents();
+
   /**
    * @brief processMouseButtonEvents get mouse event
    * and dispatch to subscribed listeners
    * @param event input mouse event
    */
-  void processMouseButtonEvents(SDL_Event &event);
+  void processMouseButtonEvents(const SDL_Event &event);
 
   /**
    * @brief processWindowEvents get window event
    * and dispatch to subscribed listeners
    * @param event input window event
    */
-  void processWindowEvents(SDL_Event &event);
+  void processWindowEvents(const SDL_Event &event);
 
   /** 
   * @brief  getOpenGlVersionString Create OpenGL version string
@@ -197,17 +253,26 @@ private:
   void initGl();
 
 
-  unsigned int  width;          /**< main screen width */
-  unsigned int  height;         /**< main screen height */
-  SDL_Window   *window;         /**< SDL identifier for current window */
-  SDL_GLContext context;        /**< SDL Handler for OpenGL Context */
+  unsigned int  width;                          /**< main screen width */
+  unsigned int  height;                         /**< main screen height */
+  SDL_Window   *window;                         /**< SDL identifier for current window */
+  SDL_GLContext context;                        /**< SDL Handler for OpenGL Context */
 
-  std::vector<bool> keystates;  /**< Keyboard pressed key status */
-  std::string       charbuffer; /**< Text input buffer */
+  SDL_Joystick *joystick;
+  SDL_GameController *controller;
 
-  static const char*        DEFAULT_TITLE;  /**< Default Title Name */
-  static const unsigned int DEFAULT_WIDTH;  /**< Default Window width */
-  static const unsigned int DEFAULT_HEIGHT; /**< Default Window Height */
+  std::vector<bool> mouseButtonStates;          /**< Mouse button pressed status */
+  std::vector<bool> keyStates;                  /**< Keyboard key pressed status */
+  std::vector<bool> controllerButtonStates;     /**< Controller button pressed status */
+  std::vector<Vector2i> controllerStickStates;  /**< Controller button pressed status */
+  std::vector<Vector2i> controllerStickMax;     /**< Controller button pressed status */
+  std::vector<int> controllerTriggerStates;     /**< Controller button pressed status */
+  std::string       charbuffer;                 /**< Text input buffer */
+  bool lastNonZero;
+
+  static const char*        DEFAULT_TITLE;      /**< Default Title Name */
+  static const unsigned int DEFAULT_WIDTH;      /**< Default Window width */
+  static const unsigned int DEFAULT_HEIGHT;     /**< Default Window Height */
 };
 
 } /* namespace radix */

--- a/include/radix/Window.hpp
+++ b/include/radix/Window.hpp
@@ -11,6 +11,7 @@
 #include <radix/input/InputSource.hpp>
 #include <radix/Viewport.hpp>
 #include <radix/core/math/Vector2i.hpp>
+#include <radix/core/math/Vector2f.hpp>
 
 namespace radix {
 
@@ -148,14 +149,7 @@ public:
    * @brief getMouseAxisValue get mouse axis value
    * @param axis x or y
    */
-  float getRelativeMouseAxisValue(const int &axis) override;
-
-  /**
-   * @brief getRelativeMouseState track mouse movement
-   * @param dx mouse x movement
-   * @param dy mouse y movement
-   */
-  void getRelativeMouseState(int *dx, int *dy) override;
+  Vector2f getRelativeMouseAxisValue() override;
 
   /**
    * @name CharBuffer methods

--- a/include/radix/core/math/Vector2f.hpp
+++ b/include/radix/core/math/Vector2f.hpp
@@ -13,6 +13,8 @@
 #ifndef VECTOR2F_HPP
 #define VECTOR2F_HPP
 
+#include <radix/core/math/Vector2i.hpp>
+
 #include <string>
 
 namespace radix {
@@ -37,6 +39,9 @@ struct Vector2f {
     : x(x), y(y) {}
   constexpr Vector2f(float v)
     : x(v), y(v) {}
+
+  constexpr Vector2f(const Vector2i &v)
+    : x(v.x), y(v.y) {}
 
   float length() const;
   std::string str() const;
@@ -99,6 +104,9 @@ struct Vector2f {
     return *this;
   }
 
+  constexpr Vector2f operator/(const Vector2f& v) const {
+    return Vector2f(x / v.x, y / v.y);
+  }
   constexpr Vector2f operator/=(const Vector2f& v) const {
     return Vector2f(x / v.x, y / v.y);
   }

--- a/include/radix/core/math/Vector2i.hpp
+++ b/include/radix/core/math/Vector2i.hpp
@@ -1,6 +1,10 @@
 #ifndef VECTOR2I_HPP
 #define VECTOR2I_HPP
+
+#include <string>
+
 namespace radix {
+
 struct Vector2i {
   union {
     int x, width;
@@ -9,6 +13,8 @@ struct Vector2i {
     int y, height;
   };
 
+  static const Vector2i ZERO, UP;
+
   constexpr Vector2i()
   : x(0), y(0) {}
   constexpr Vector2i(int x, int y)
@@ -16,6 +22,19 @@ struct Vector2i {
   constexpr Vector2i(int v)
   : x(v), y(v) {}
 
+  std::string str() const;
+
+  constexpr bool operator==(const Vector2i &v) const {
+    return x == v.x && y == v.y;
+  }
+
+  constexpr bool operator!=(const Vector2i &v) const {
+    return x != v.x || y != v.y;
+  }
+
+  constexpr Vector2i operator-(const Vector2i& v) const {
+    return Vector2i(x - v.x, y - v.y);
+  }
 };
 } /* namespace radix */
 #endif /* VECTOR2I_HPP */

--- a/include/radix/entities/Player.hpp
+++ b/include/radix/entities/Player.hpp
@@ -14,6 +14,9 @@
 #include <radix/util/BulletGhostPairCallbacks.hpp>
 
 namespace radix {
+
+class Vector2f;
+
 namespace entities {
 
 class Player :
@@ -29,9 +32,11 @@ public:
   KinematicCharacterController *controller;
 
   Vector3f velocity, headAngle;
-  bool flying, noclip, frozen;
+  bool flying, noclip, frozen, attemptJump;
   float speed;
   float stepCounter;
+  Vector3f movement;
+  Vector3f headingChange;
 
   Trigger *trigger;
 
@@ -39,6 +44,11 @@ public:
   ~Player();
 
   void tick(TDelta) override;
+  void jump();
+  void move(const Vector2f &move);
+  void moveX(const float &move);
+  void moveY(const float &move);
+  void changeHeading(const Vector2f& lookVector);
 
   Quaternion getBaseHeadOrientation() const;
   Quaternion getHeadOrientation() const;

--- a/include/radix/env/Config.hpp
+++ b/include/radix/env/Config.hpp
@@ -2,10 +2,14 @@
 #define RADIX_CONFIG_HPP
 
 #include <string>
+#include <vector>
+#include <map>
 
 #include <json11/json11.hpp>
 
 #include <radix/core/diag/Logger.hpp>
+#include <radix/input/Bind.hpp>
+
 using namespace json11;
 
 namespace radix {
@@ -20,53 +24,58 @@ class Config {
 friend class ArgumentsParser;
 
 public:
+  using Bindings = std::vector<std::vector<Bind>>;
+
   Config();
   void load();
   bool isLoaded();
-  unsigned int getWidth() const { return width; }
-  unsigned int getHeight() const { return height; }
-  float getSensitivity() const { return sensitivity; }
-  bool isFullscreen() const { return fullscreen; }
-  int getAntialiasLevel() const { return antialiasing; }
-  int getRecursionLevel() const { return recursivePortal; }
-  bool hasSound() const { return sound; }
-  bool hasVsync() const { return vsync; }
-  bool isHidePortalsByClick() const { return hidePortalsByClick; }
-  bool isConsoleEnabled() const { return consoleEnabled; }
-  bool isProfilerEnabled() const { return profilerEnabled; }
-  bool isFlyingEnabled() const { return flyingEnabled; }
-  bool isDebugViewEnabled() const { return debugViewEnabled; }
-  bool getCursorVisibility() const { return cursorVisibility; }
-  bool getIgnoreGlVersion() const { return ignoreGlVersion; }
-  bool getGlContextEnableDebug() const { return glContextEnableDebug; }
-  LogLevel getLoglevel() const { return loglevel; }
-  std::string getMap() const { return map; }
-  std::string getMapPath() const { return mapPath; }
-  int getScreen() const { return screen; }
+  unsigned int getWidth()         const { return width; }
+  unsigned int getHeight()        const { return height; }
+  float getMouseSensitivity()     const { return mouseSensitivity; }
+  bool isFullscreen()             const { return fullscreen; }
+  int getAntialiasLevel()         const { return antialiasing; }
+  int getRecursionLevel()         const { return recursivePortal; }
+  bool hasSound()                 const { return sound; }
+  bool hasVsync()                 const { return vsync; }
+  bool isHidePortalsByClick()     const { return hidePortalsByClick; }
+  bool isConsoleEnabled()         const { return consoleEnabled; }
+  bool isProfilerEnabled()        const { return profilerEnabled; }
+  bool isFlyingEnabled()          const { return flyingEnabled; }
+  bool isDebugViewEnabled()       const { return debugViewEnabled; }
+  bool getCursorVisibility()      const { return cursorVisibility; }
+  bool getIgnoreGlVersion()       const { return ignoreGlVersion; }
+  bool getGlContextEnableDebug()  const { return glContextEnableDebug; }
+  Bindings getBindings()          const { return bindings; }
+  LogLevel getLoglevel()          const { return loglevel; }
+  std::string getMap()            const { return map; }
+  std::string getMapPath()        const { return mapPath; }
+  int getScreen()                 const { return screen; }
+
+  static std::string actionToString(const int &action);
 
 private:
   void loadVideoSettings(const Json &json);
   void loadSoundSettings(const Json &json);
   void loadMouseSettings(const Json &json);
+  void loadKeyboardSettings(const Json &json);
+  void loadControllerSettings(const Json &json);
   void loadLoglevelSettings(const Json &json);
+  void loadDefaultBindings();
 
-  bool loaded;
   unsigned int width;
   unsigned int height;
-  float sensitivity;
+  float mouseSensitivity;
   int antialiasing;
   int recursivePortal;
-  bool fullscreen;
-  bool sound;
-  bool vsync;
-  bool hidePortalsByClick;
-  bool cursorVisibility;
-  bool ignoreGlVersion;
-  bool glContextEnableDebug;
-  bool consoleEnabled;
-  bool profilerEnabled;
-  bool flyingEnabled;
-  bool debugViewEnabled;
+  bool loaded, fullscreen, sound, vsync, flyingEnabled
+    , hidePortalsByClick, cursorVisibility
+    , ignoreGlVersion, glContextEnableDebug
+    , consoleEnabled, profilerEnabled, debugViewEnabled;
+
+  Bindings bindings;
+
+  static const Bindings defaultBindings;
+
   LogLevel loglevel;
   std::string map;
   std::string mapPath;

--- a/include/radix/input/Bind.hpp
+++ b/include/radix/input/Bind.hpp
@@ -23,18 +23,19 @@ struct Bind {
   };
   static bool isInputTypeDigital(const int& input) {
     switch (input) {
-    case KEYBOARD:
-    case MOUSE_BUTTON:
-    case CONTROLLER_BUTTON: {
-      return true;
-      break;
-    }
     case MOUSE_AXIS:
     case CONTROLLER_AXIS:
-    case CONTROLLER_TRIGGER:
-    case INPUT_TYPE_INVALID:
-    case INPUT_TYPE_MAX: {
+    case CONTROLLER_TRIGGER: {
       return false;
+      break;
+    }
+    case KEYBOARD:
+    case MOUSE_BUTTON:
+    case CONTROLLER_BUTTON:
+    case INPUT_TYPE_INVALID:
+    case INPUT_TYPE_MAX:
+    default: {
+      return true;
       break;
     }
     }

--- a/include/radix/input/Bind.hpp
+++ b/include/radix/input/Bind.hpp
@@ -1,0 +1,59 @@
+#ifndef RADIX_BIND_HPP
+#define RADIX_BIND_HPP
+
+namespace radix {
+	
+struct Bind {
+  int8_t action;
+  int8_t inputType;
+  int8_t inputCode;
+  float sensitivity;
+  union {
+    float deadZone, actPoint;
+  };
+	enum InputType : int8_t {
+	  INPUT_TYPE_INVALID = -1,
+	  KEYBOARD = 0,
+	  MOUSE_BUTTON = 1,
+	  MOUSE_AXIS = 2,
+	  CONTROLLER_BUTTON = 3,
+    CONTROLLER_AXIS = 4,
+	  CONTROLLER_TRIGGER = 5,
+	  INPUT_TYPE_MAX = 6
+	};
+  static bool isInputTypeDigital(const int& input) {
+    switch (input) {
+    case KEYBOARD:
+    case MOUSE_BUTTON:
+    case CONTROLLER_BUTTON: {
+      return true;
+      break;
+    }
+    case MOUSE_AXIS:
+    case CONTROLLER_AXIS:
+    case CONTROLLER_TRIGGER:
+    case INPUT_TYPE_INVALID:
+    case INPUT_TYPE_MAX: {
+      return false;
+      break;
+    }
+    }
+  }
+
+  Bind()
+    :action(-1),
+    inputType(-1),
+    inputCode(-1),
+    sensitivity(0.0f),
+    deadZone(0.0f) {}
+  Bind(const int &action, const int &inputType, const int &inputCode, const float &sensitivity = 0.0f, const float &deadZone = 0.5)
+  : action(action),
+  inputType(inputType),
+  inputCode(inputCode),
+  sensitivity(sensitivity),
+  deadZone(deadZone) {}
+};
+
+}
+
+#endif /* RADIX_BIND_HPP */

--- a/include/radix/input/Bind.hpp
+++ b/include/radix/input/Bind.hpp
@@ -11,16 +11,16 @@ struct Bind {
   union {
     float deadZone, actPoint;
   };
-	enum InputType : int8_t {
-	  INPUT_TYPE_INVALID = -1,
-	  KEYBOARD = 0,
-	  MOUSE_BUTTON = 1,
-	  MOUSE_AXIS = 2,
-	  CONTROLLER_BUTTON = 3,
+  enum InputType : int8_t {
+    INPUT_TYPE_INVALID = -1,
+    KEYBOARD = 0,
+    MOUSE_BUTTON = 1,
+    MOUSE_AXIS = 2,
+    CONTROLLER_BUTTON = 3,
     CONTROLLER_AXIS = 4,
-	  CONTROLLER_TRIGGER = 5,
-	  INPUT_TYPE_MAX = 6
-	};
+    CONTROLLER_TRIGGER = 5,
+    INPUT_TYPE_MAX = 6
+  };
   static bool isInputTypeDigital(const int& input) {
     switch (input) {
     case KEYBOARD:
@@ -40,18 +40,18 @@ struct Bind {
     }
   }
 
-  Bind()
-    :action(-1),
+  Bind() :
+    action(-1),
     inputType(-1),
     inputCode(-1),
     sensitivity(0.0f),
     deadZone(0.0f) {}
-  Bind(const int &action, const int &inputType, const int &inputCode, const float &sensitivity = 0.0f, const float &deadZone = 0.5)
-  : action(action),
-  inputType(inputType),
-  inputCode(inputCode),
-  sensitivity(sensitivity),
-  deadZone(deadZone) {}
+  Bind(const int &action, const int &inputType, const int &inputCode, const float &sensitivity = 0.0f, const float &deadZone = 0.5) : 
+    action(action),
+    inputType(inputType),
+    inputCode(inputCode),
+    sensitivity(sensitivity),
+    deadZone(deadZone) {}
 };
 
 }

--- a/include/radix/input/Channel.hpp
+++ b/include/radix/input/Channel.hpp
@@ -18,37 +18,37 @@ class SubChannel;
 template<class T>
 class Channel: public ChannelBase<T>, ChannelListener {
 public:
-	Channel() = default;
-	Channel(ChannelListener *listener)
-		: ChannelBase<T>(listener) {}
-	Channel(ChannelListener *listener, const int &id, EventDispatcher &event, const std::vector<Bind> &binds)
-		: ChannelBase<T>(listener) {
-		this->init(id, event, binds);
-	}
-	void init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds);
+  Channel() = default;
+  Channel(ChannelListener *listener)
+    : ChannelBase<T>(listener) {}
+  Channel(ChannelListener *listener, const int &id, EventDispatcher &event, const std::vector<Bind> &binds)
+    : ChannelBase<T>(listener) {
+    this->init(id, event, binds);
+  }
+  void init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds);
 
-	virtual void channelChanged(const int &id) override;
+  virtual void channelChanged(const int &id) override;
 
 protected:
-	std::vector<SubChannel<T>> subChannels;
+  std::vector<SubChannel<T>> subChannels;
 
 };
 
 template<class T>
 class SubChannel: public ChannelBase<T> {
 public:
-	SubChannel() = default;
-	SubChannel(ChannelListener *listener)
-		: ChannelBase<T>(listener) {}
-	SubChannel(ChannelListener *listener, const int &id, EventDispatcher &event, const Bind &bind)
-		: ChannelBase<T>(listener) {
-		this->init(id, event, bind);
-	}
-	void init(const int &id, EventDispatcher &event, const Bind &bind);
+  SubChannel() = default;
+  SubChannel(ChannelListener *listener)
+    : ChannelBase<T>(listener) {}
+  SubChannel(ChannelListener *listener, const int &id, EventDispatcher &event, const Bind &bind)
+    : ChannelBase<T>(listener) {
+    this->init(id, event, bind);
+  }
+  void init(const int &id, EventDispatcher &event, const Bind &bind);
 
 protected:
-	Bind bind;
-	std::array<EventDispatcher::CallbackHolder, 2> callbacks;
+  Bind bind;
+  std::array<EventDispatcher::CallbackHolder, 2> callbacks;
 
 };
 

--- a/include/radix/input/Channel.hpp
+++ b/include/radix/input/Channel.hpp
@@ -1,0 +1,57 @@
+#ifndef RADIX_CHANNEL_HPP
+#define RADIX_CHANNEL_HPP
+
+#include <vector>
+#include <array>
+
+#include <radix/core/event/EventDispatcher.hpp>
+#include <radix/core/math/Vector2f.hpp>
+#include <radix/input/ChannelListener.hpp>
+#include <radix/input/ChannelBase.hpp>
+#include <radix/input/Bind.hpp>
+
+namespace radix {
+
+template<class T>
+class SubChannel;
+
+template<class T>
+class Channel: public ChannelBase<T>, ChannelListener {
+public:
+	Channel() = default;
+	Channel(ChannelListener *listener)
+		: ChannelBase<T>(listener) {}
+	Channel(ChannelListener *listener, const int &id, EventDispatcher &event, const std::vector<Bind> &binds)
+		: ChannelBase<T>(listener) {
+		this->init(id, event, binds);
+	}
+	void init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds);
+
+	virtual void channelChanged(const int &id) override;
+
+protected:
+	std::vector<SubChannel<T>> subChannels;
+
+};
+
+template<class T>
+class SubChannel: public ChannelBase<T> {
+public:
+	SubChannel() = default;
+	SubChannel(ChannelListener *listener)
+		: ChannelBase<T>(listener) {}
+	SubChannel(ChannelListener *listener, const int &id, EventDispatcher &event, const Bind &bind)
+		: ChannelBase<T>(listener) {
+		this->init(id, event, bind);
+	}
+	void init(const int &id, EventDispatcher &event, const Bind &bind);
+
+protected:
+	Bind bind;
+	std::array<EventDispatcher::CallbackHolder, 2> callbacks;
+
+};
+
+}
+
+#endif /* RADIX_INPUT_MANAGER_HPP */

--- a/include/radix/input/ChannelBase.hpp
+++ b/include/radix/input/ChannelBase.hpp
@@ -1,0 +1,43 @@
+#ifndef RADIX_CHANNEL_BASE_HPP
+#define RADIX_CHANNEL_BASE_HPP
+
+#include <vector>
+
+namespace radix {
+
+class ChannelListener;
+
+template <class T>
+class ChannelBase {
+public:
+	ChannelBase();
+	ChannelBase(ChannelListener *listener);
+
+	void setId(const int &id) { this->id = id; }
+	void addListener(ChannelListener* listener);
+	void setDigital(const float &actPoint);
+	void setAnalogue(const float &deadZone);
+	void setBound(const float& bound);
+	void setSensitivity(const float& sensitivity) { this->sensitivity = sensitivity; }
+	void setAutoZero() { autoZero = true; }
+	void setAlwaysNotifyListener() { alwaysNotifyListener = true; }
+	void set(T newValue);
+	int getId() const { return id; }
+	T get() const { return value; }
+
+protected:
+	void notifyListeners();
+
+	std::vector<ChannelListener*> listeners;
+	int id;
+	float bound, sensitivity;
+	bool hasBound, isDigital, autoZero, alwaysNotifyListener;
+	union {
+		float deadZone, actPoint;
+	};
+	T value;
+};
+
+}
+
+#endif /* RADIX_INPUT_MANAGER_HPP */

--- a/include/radix/input/ChannelBase.hpp
+++ b/include/radix/input/ChannelBase.hpp
@@ -10,32 +10,33 @@ class ChannelListener;
 template <class T>
 class ChannelBase {
 public:
-	ChannelBase();
-	ChannelBase(ChannelListener *listener);
+  ChannelBase();
+  ChannelBase(ChannelListener *listener);
 
-	void setId(const int &id) { this->id = id; }
-	void addListener(ChannelListener* listener);
-	void setDigital(const float &actPoint);
-	void setAnalogue(const float &deadZone);
-	void setBound(const float& bound);
-	void setSensitivity(const float& sensitivity) { this->sensitivity = sensitivity; }
-	void setAutoZero() { autoZero = true; }
-	void setAlwaysNotifyListener() { alwaysNotifyListener = true; }
-	void set(T newValue);
-	int getId() const { return id; }
-	T get() const { return value; }
+  void setId(const int &id) { this->id = id; }
+  void addListener(ChannelListener* listener);
+  void setDigital(const float &actPoint);
+  void setAnalogue(const float &deadZone);
+  void setBound(const float& bound);
+  void setSensitivity(const float& sensitivity) { this->sensitivity = sensitivity; }
+  void setAutoZero() { autoZero = true; }
+  void setAlwaysNotifyListener() { alwaysNotifyListener = true; }
+  void set(T newValue);
+  int getId() const { return id; }
+  T get() const { return value; }
 
 protected:
-	void notifyListeners();
+  void notifyListeners();
 
-	std::vector<ChannelListener*> listeners;
-	int id;
-	float bound, sensitivity;
-	bool hasBound, isDigital, autoZero, alwaysNotifyListener;
-	union {
-		float deadZone, actPoint;
-	};
-	T value;
+  std::vector<ChannelListener*> listeners;
+  int id;
+  float bound, sensitivity;
+  bool hasBound, isDigital, autoZero, alwaysNotifyListener;
+  union {
+    float deadZone, actPoint;
+  };
+  T value;
+
 };
 
 }

--- a/include/radix/input/ChannelListener.hpp
+++ b/include/radix/input/ChannelListener.hpp
@@ -1,0 +1,14 @@
+#ifndef RADIX_CHANNEL_LISTENER_HPP
+#define RADIX_CHANNEL_LISTENER_HPP
+
+namespace radix {
+
+class ChannelListener {
+public:
+	virtual void channelChanged(const int &id) = 0;
+
+};
+
+}
+
+#endif /* RADIX_INPUT_MANAGER_HPP */

--- a/include/radix/input/ChannelListener.hpp
+++ b/include/radix/input/ChannelListener.hpp
@@ -5,7 +5,7 @@ namespace radix {
 
 class ChannelListener {
 public:
-	virtual void channelChanged(const int &id) = 0;
+  virtual void channelChanged(const int &id) = 0;
 
 };
 

--- a/include/radix/input/InputManager.hpp
+++ b/include/radix/input/InputManager.hpp
@@ -15,37 +15,37 @@ class EventDispatcher;
 
 class InputManager : public ChannelListener {
 public:
-	enum Action : int8_t {
-		ACTION_INVALID = -1,
-		PLAYER_MOVE_ANALOGUE = 0,
-		PLAYER_LOOK_ANALOGUE,
-		PLAYER_JUMP,
-		PLAYER_PORTAL_0,
-		PLAYER_PORTAL_1,
-		PLAYER_FORWARD,
-		PLAYER_BACK,
-		PLAYER_LEFT,
-		PLAYER_RIGHT,
-		GAME_PAUSE,
-		GAME_QUIT,
-		ACTION_MAX
-	};
+  enum Action : int8_t {
+    ACTION_INVALID = -1,
+    PLAYER_MOVE_ANALOGUE = 0,
+    PLAYER_LOOK_ANALOGUE,
+    PLAYER_JUMP,
+    PLAYER_PORTAL_0,
+    PLAYER_PORTAL_1,
+    PLAYER_FORWARD,
+    PLAYER_BACK,
+    PLAYER_LEFT,
+    PLAYER_RIGHT,
+    GAME_PAUSE,
+    GAME_QUIT,
+    ACTION_MAX
+  };
 
-	InputManager() = delete;
-	InputManager(BaseGame &baseGame);
-	void setConfig(const Config &config);
-	void init(EventDispatcher &event);
+  InputManager() = delete;
+  InputManager(BaseGame &baseGame);
+  void setConfig(const Config &config);
+  void init(EventDispatcher &event);
 
-	virtual void channelChanged(const int &id) override;
-	Vector2f getPlayerMovementVector() const;
+  virtual void channelChanged(const int &id) override;
+  Vector2f getPlayerMovementVector() const;
 
-	static bool isActionDigital(const int &act);
+  static bool isActionDigital(const int &act);
 
 protected:
-	BaseGame &game;
-	Config config;
-	std::map<int, Channel<float>> 	digitalChannels;
-	std::map<int, Channel<Vector2f>> analogueChannels;
+  BaseGame &game;
+  Config config;
+  std::map<int, Channel<float>> 	digitalChannels;
+  std::map<int, Channel<Vector2f>> analogueChannels;
 
 };
 

--- a/include/radix/input/InputManager.hpp
+++ b/include/radix/input/InputManager.hpp
@@ -1,0 +1,54 @@
+#ifndef RADIX_INPUT_MANAGER_HPP
+#define RADIX_INPUT_MANAGER_HPP
+
+#include <array>
+
+#include <radix/core/math/Vector2f.hpp>
+#include <radix/env/Config.hpp>
+#include <radix/input/Channel.hpp>
+#include <radix/input/ChannelListener.hpp>
+
+namespace radix {
+
+class BaseGame;
+class EventDispatcher;
+
+class InputManager : public ChannelListener {
+public:
+	enum Action : int8_t {
+		ACTION_INVALID = -1,
+		PLAYER_MOVE_ANALOGUE = 0,
+		PLAYER_LOOK_ANALOGUE,
+		PLAYER_JUMP,
+		PLAYER_PORTAL_0,
+		PLAYER_PORTAL_1,
+		PLAYER_FORWARD,
+		PLAYER_BACK,
+		PLAYER_LEFT,
+		PLAYER_RIGHT,
+		GAME_PAUSE,
+		GAME_QUIT,
+		ACTION_MAX
+	};
+
+	InputManager() = delete;
+	InputManager(BaseGame &baseGame);
+	void setConfig(const Config &config);
+	void init(EventDispatcher &event);
+
+	virtual void channelChanged(const int &id) override;
+	Vector2f getPlayerMovementVector() const;
+
+	static bool isActionDigital(const int &act);
+
+protected:
+	BaseGame &game;
+	Config config;
+	std::map<int, Channel<float>> 	digitalChannels;
+	std::map<int, Channel<Vector2f>> analogueChannels;
+
+};
+
+}
+
+#endif /* RADIX_INPUT_MANAGER_HPP */

--- a/include/radix/input/InputSource.hpp
+++ b/include/radix/input/InputSource.hpp
@@ -4,10 +4,12 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <map>
 
 #include <SDL2/SDL.h>
 
 #include <radix/core/event/Event.hpp>
+#include <radix/core/math/Vector2f.hpp>
 
 namespace radix {
 
@@ -29,7 +31,7 @@ public:
     InputSource &source;
     const KeyboardKey key;
     const KeyboardModifier mod;
-    KeyPressedEvent(InputSource &source, KeyboardKey key, KeyboardModifier mod)
+    KeyPressedEvent(InputSource &source, const KeyboardKey &key, const KeyboardModifier &mod)
       : source(source), key(key), mod(mod) {}
   };
   struct KeyReleasedEvent : public Event {
@@ -37,51 +39,115 @@ public:
     InputSource &source;
     const KeyboardKey key;
     const KeyboardModifier mod;
-    KeyReleasedEvent(InputSource &source, KeyboardKey key, KeyboardModifier mod)
+    KeyReleasedEvent(InputSource &source, const KeyboardKey &key, const KeyboardModifier &mod)
       : source(source), key(key), mod(mod) {}
   };
 
   /* ================= */
   /*   Mouse buttons   */
   /* ================= */
-  enum class MouseButton : uint8_t {
+  using MouseAxisValue = Vector2f;
+
+  enum class MouseButton : int8_t {
+    Invalid = -1,
     Left = 0,
-    Right = 1,
-    Middle = 2,
+    Middle = 1,
+    Right = 2,
     Aux1,
     Aux2,
     Aux3,
     Aux4,
     Aux5,
     Aux6,
-    Aux7,
-    Aux8,
-    Unknown = 0xFF
+    Max
   };
   struct MouseButtonPressedEvent : public Event {
     radix_event_declare("radix/InputSource:MouseButtonPressed")
     InputSource &source;
     const MouseButton button;
-    MouseButtonPressedEvent(InputSource &source, MouseButton button)
+    MouseButtonPressedEvent(InputSource &source, const MouseButton &button)
       : source(source), button(button) {}
   };
   struct MouseButtonReleasedEvent : public Event {
     radix_event_declare("radix/InputSource:MouseButtonReleased")
     InputSource &source;
     const MouseButton button;
-    MouseButtonReleasedEvent(InputSource &source, MouseButton button)
+    MouseButtonReleasedEvent(InputSource &source, const MouseButton &button)
       : source(source), button(button) {}
   };
-
-  /* =============== */
-  /*   Mouse wheel   */
-  /* =============== */
+  struct MouseAxisEvent : public Event {
+    radix_event_declare("radix/InputSource:MouseMoved")
+    InputSource &source;
+    const MouseAxisValue value;
+    MouseAxisEvent(InputSource &source, const MouseAxisValue &value)
+      : source(source), value(value) {}
+  };
   struct MouseWheelScrolledEvent : public Event {
     radix_event_declare("radix/InputSource:MouseWheelScrolled")
     InputSource &source;
     const int x, y;
-    MouseWheelScrolledEvent(InputSource &source, int x, int y)
+    MouseWheelScrolledEvent(InputSource &source, const int &x, const int &y)
       : source(source), x(x), y(y) {}
+  };
+
+public:
+  /* ================= */
+  /*    Controller     */
+  /* ================= */
+  using ControllerButton = int;
+  using ControllerAxis = int;     // 0/1 for left/right respectively
+  using ControllerTrigger = int;  // 0/1 for left/right respectively
+  using ControllerIndex = int;
+  using ControllerAxisValue = Vector2f;
+  using ControllerTriggerValue = float;
+
+  struct ControllerButtonPressedEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerButtonPressed")
+    InputSource &source;
+    const ControllerButton button;
+    const ControllerIndex index;
+    ControllerButtonPressedEvent(InputSource &source, const ControllerButton &button, const ControllerIndex &index)
+      : source(source), button(button), index(index) {}
+  };
+  struct ControllerButtonReleasedEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerButtonReleased")
+    InputSource &source;
+    const ControllerButton button;
+    const ControllerIndex index;
+    ControllerButtonReleasedEvent(InputSource &source, const ControllerButton &button, const ControllerIndex &index)
+      : source(source), button(button), index(index) {}
+  };
+  struct ControllerAxisEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerAxis")
+    InputSource &source;
+    const ControllerAxis axis;
+    const ControllerAxisValue value;
+    const ControllerIndex index;
+    ControllerAxisEvent(InputSource &source, const ControllerAxis &axis, const ControllerAxisValue &value, const ControllerIndex &index)
+      : source(source), axis(axis), value(value), index(index) {}
+  };
+  struct ControllerTriggerEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerTrigger")
+    InputSource &source;
+    const ControllerTrigger trigger;
+    const ControllerTriggerValue value;
+    const ControllerIndex index;
+    ControllerTriggerEvent(InputSource &source, const ControllerTrigger &trigger, const ControllerTriggerValue &value , const ControllerIndex &index)
+      : source(source), trigger(trigger), value(value), index(index) {}
+  };
+  struct ControllerAddedEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerAdded")
+    InputSource &source;
+    const ControllerIndex index;
+    ControllerAddedEvent(InputSource &source, const ControllerIndex &index)
+      : source(source), index(index) {}
+  };
+  struct ControllerRemovedEvent : public Event {
+    radix_event_declare("radix/InputSource:ControllerRemoved")
+    InputSource &source;
+    const ControllerIndex index;
+    ControllerRemovedEvent(InputSource &source, const ControllerIndex &index)
+      : source(source), index(index) {}
   };
 
   /* =============== */
@@ -90,104 +156,104 @@ public:
   struct WindowShownEvent : public Event {
     radix_event_declare("radix/InputSource:WindowShown")
     InputSource &source;
-    Uint32 windowID;
-    WindowShownEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowShownEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowHiddenEvent : public Event {
     radix_event_declare("radix/InputSource:WindowHidden")
     InputSource &source;
-    Uint32 windowID;
-    WindowHiddenEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowHiddenEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowExposedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowExposed")
     InputSource &source;
-    Uint32 windowID;
-    WindowExposedEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowExposedEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowMovedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowMoved")
     InputSource &source;
-    Uint32 windowID;
-    Sint32 x;
-    Sint32 y;
+    const Uint32 windowID;
+    const Sint32 x;
+    const Sint32 y;
     WindowMovedEvent(InputSource &source, Uint32 windowID, Sint32 x, Sint32 y)
         : source(source), windowID(windowID), x(x), y(y) {}
   };
   struct WindowResizedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowResized")
     InputSource &source;
-    Uint32 windowID;
-    Sint32 x;
-    Sint32 y;
-    WindowResizedEvent(InputSource &source, Uint32 windowID, Sint32 x, Sint32 y)
+    const Uint32 windowID;
+    const Sint32 x;
+    const Sint32 y;
+    WindowResizedEvent(InputSource &source, const Uint32 & windowID, const Sint32 &x, const Sint32 &y)
         : source(source), windowID(windowID), x(x), y(y) {}
   };
   struct WindowSizeChangedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowSizeChanged")
     InputSource &source;
-    Uint32 windowID;
-    WindowSizeChangedEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowSizeChangedEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
 
   struct WindowMinimizedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowMinimized")
     InputSource &source;
-    Uint32 windowID;
-    WindowMinimizedEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowMinimizedEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowMaximizedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowMaximized")
     InputSource &source;
-    Uint32 windowID;
-    WindowMaximizedEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowMaximizedEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowRestoredEvent : public Event {
     radix_event_declare("radix/InputSource:WindowRestored")
     InputSource &source;
-    Uint32 windowID;
-    WindowRestoredEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowRestoredEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowEnterEvent : public Event {
     radix_event_declare("radix/InputSource:EnterExposed")
     InputSource &source;
-    Uint32 windowID;
-    WindowEnterEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowEnterEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowLeaveEvent : public Event {
     radix_event_declare("radix/InputSource:WindowLeave")
     InputSource &source;
-    Uint32 windowID;
-    WindowLeaveEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowLeaveEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowFocusGainedEvent : public Event {
     radix_event_declare("radix/InputSource:WindowFocusGained")
     InputSource &source;
-    Uint32 windowID;
-    WindowFocusGainedEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowFocusGainedEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowFocusLostEvent : public Event {
     radix_event_declare("radix/InputSource:FocusLost")
     InputSource &source;
-    Uint32 windowID;
-    WindowFocusLostEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowFocusLostEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
   struct WindowCloseEvent : public Event {
     radix_event_declare("radix/InputSource:WindowClose")
     InputSource &source;
-    Uint32 windowID;
-    WindowCloseEvent(InputSource &source, Uint32 windowID)
+    const Uint32 windowID;
+    WindowCloseEvent(InputSource &source, const Uint32 &windowID)
         : source(source), windowID(windowID) {}
   };
 
@@ -197,14 +263,34 @@ public:
   void removeDispatcher(EventDispatcher &d);
 
   virtual void processEvents() = 0;
-  virtual void keyPressed(KeyboardKey key, KeyboardModifier mod) = 0;
-  virtual void keyReleased(KeyboardKey key, KeyboardModifier mod) = 0;
-  virtual bool isKeyDown(KeyboardKey key) = 0;
+  virtual void keyPressed(const KeyboardKey &key, const KeyboardModifier &mod) = 0;
+  virtual void keyReleased(const KeyboardKey &key, const KeyboardModifier &mod) = 0;
+  virtual bool isKeyDown(const KeyboardKey &key) = 0;
+  virtual void controllerButtonPressed(const ControllerButton &button, const ControllerIndex &index) = 0;
+  virtual void controllerButtonReleased(const ControllerButton &button, const ControllerIndex &index) = 0;
+  virtual bool isControllerButtonDown(const ControllerButton &button, const ControllerIndex &index) = 0;
+  virtual float getControllerAxisValue(const ControllerAxis &axis, const ControllerIndex &index) = 0;
+  virtual bool isMouseButtonDown(const int &button) = 0;
+  virtual float getRelativeMouseAxisValue(const int &axis) = 0;
+  virtual void getRelativeMouseState(int *dx, int *dy) = 0;
   virtual std::string getCharBuffer() = 0;
   virtual void addToBuffer(const std::string &character) = 0;
   virtual void clearBuffer() = 0;
   virtual void truncateCharBuffer() = 0;
   virtual void clear() = 0;
+
+  using LookUpTable = std::map<std::string, int>;
+
+private:
+  static const LookUpTable mouseButtonLookUp;
+  static const LookUpTable controllerButtonLookUp;
+
+public:
+  static int keyboardGetKeyFromString(const std::string &keyStr);
+  static int mouseGetButtonFromString(const std::string &buttonStr);
+  static int gameControllerGetButtonFromString(const std::string &buttonStr);
+  static int gameControllerGetAxisFromString(const std::string &axisStr);
+  static int gameControllerGetTriggerFromString(const std::string &triggerStr);
 };
 
 } /* namespace radix */

--- a/include/radix/input/InputSource.hpp
+++ b/include/radix/input/InputSource.hpp
@@ -271,8 +271,7 @@ public:
   virtual bool isControllerButtonDown(const ControllerButton &button, const ControllerIndex &index) = 0;
   virtual float getControllerAxisValue(const ControllerAxis &axis, const ControllerIndex &index) = 0;
   virtual bool isMouseButtonDown(const int &button) = 0;
-  virtual float getRelativeMouseAxisValue(const int &axis) = 0;
-  virtual void getRelativeMouseState(int *dx, int *dy) = 0;
+  virtual Vector2f getRelativeMouseAxisValue() = 0;
   virtual std::string getCharBuffer() = 0;
   virtual void addToBuffer(const std::string &character) = 0;
   virtual void clearBuffer() = 0;

--- a/source/BaseGame.cpp
+++ b/source/BaseGame.cpp
@@ -140,9 +140,9 @@ void BaseGame::removeHook() { }
 void BaseGame::customTriggerHook() { }
 
 void BaseGame::cleanUp() {
-	removeHook();
-  setWorld({});
-  window.close();
+        removeHook();
+        setWorld({});
+        window.close();
 }
 
 void BaseGame::render() {

--- a/source/BaseGame.cpp
+++ b/source/BaseGame.cpp
@@ -20,8 +20,8 @@ namespace radix {
 Fps BaseGame::fps;
 
 BaseGame::BaseGame() :
-    config(),
     inputManager(*this),
+    config(),
     gameWorld(window),
     closed(false) {
   radix::Environment::init();

--- a/source/BaseGame.cpp
+++ b/source/BaseGame.cpp
@@ -43,6 +43,7 @@ BaseGame::~BaseGame() {
     profiler::stopListen();
     PROFILER_PROFILER_DISABLE;
   }
+  screenshotCallbackHolder.removeThis();
 }
 
 void BaseGame::setup() {
@@ -135,9 +136,11 @@ void BaseGame::deferPostCycle(const std::function<void()> &deferred) {
 
 void BaseGame::processInput() { } /* to avoid pure virtual function */
 void BaseGame::initHook() { }
+void BaseGame::removeHook() { }
 void BaseGame::customTriggerHook() { }
 
 void BaseGame::cleanUp() {
+	removeHook();
   setWorld({});
   window.close();
 }

--- a/source/BaseGame.cpp
+++ b/source/BaseGame.cpp
@@ -21,6 +21,7 @@ Fps BaseGame::fps;
 
 BaseGame::BaseGame() :
     config(),
+    inputManager(*this),
     gameWorld(window),
     closed(false) {
   radix::Environment::init();
@@ -34,6 +35,7 @@ BaseGame::BaseGame() :
   }
 
   window.setConfig(config);
+  inputManager.setConfig(config);
 }
 
 BaseGame::~BaseGame() {
@@ -41,7 +43,6 @@ BaseGame::~BaseGame() {
     profiler::stopListen();
     PROFILER_PROFILER_DISABLE;
   }
-  screenshotCallbackHolder.removeThis();
 }
 
 void BaseGame::setup() {
@@ -68,6 +69,8 @@ void BaseGame::setup() {
 
   screenRenderer = std::make_unique<ScreenRenderer>(*world, *renderer.get(), gameWorld);
   renderer->addRenderer(*screenRenderer);
+
+  inputManager.init(getWorld()->event);
 }
 
 bool BaseGame::isRunning() {
@@ -76,6 +79,10 @@ bool BaseGame::isRunning() {
 
 World* BaseGame::getWorld() {
   return world.get();
+}
+
+Config& BaseGame::getConfig() {
+  return config;
 }
 
 void BaseGame::switchToOtherWorld(const std::string &name) {
@@ -128,11 +135,9 @@ void BaseGame::deferPostCycle(const std::function<void()> &deferred) {
 
 void BaseGame::processInput() { } /* to avoid pure virtual function */
 void BaseGame::initHook() { }
-void BaseGame::removeHook() { }
 void BaseGame::customTriggerHook() { }
 
 void BaseGame::cleanUp() {
-  removeHook();
   setWorld({});
   window.close();
 }

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -22,6 +22,7 @@ set(RADIX_SOURCES
   ${D}/core/math/Matrix3f.cpp
   ${D}/core/math/Matrix4f.cpp
   ${D}/core/math/Vector2f.cpp
+  ${D}/core/math/Vector2i.cpp
   ${D}/core/math/Vector2ui.cpp
   ${D}/core/math/Vector3f.cpp
   ${D}/core/math/Vector4f.cpp
@@ -43,6 +44,9 @@ set(RADIX_SOURCES
   ${D}/env/Util.cpp
   ${D}/GameWorld.cpp
   ${D}/input/InputSource.cpp
+  ${D}/input/InputManager.cpp
+  ${D}/input/ChannelBase.cpp
+  ${D}/input/Channel.cpp
   ${D}/data/map/MapListLoader.cpp
   ${D}/data/map/MapListLoader.cpp
   ${D}/data/map/MapLoader.cpp

--- a/source/Window.cpp
+++ b/source/Window.cpp
@@ -66,7 +66,7 @@ void Window::initGl() {
   } else {
     if (glversion < 32) {
       throw Exception::Error("Window", std::string("OpenGL Version ") + versionString +
-                             " is unsupported, required minimum is 3.2");
+                             " is unsupported, " "required minimum is 3.2");
     }
   }
 }

--- a/source/Window.cpp
+++ b/source/Window.cpp
@@ -26,6 +26,7 @@ const unsigned int Window::DEFAULT_HEIGHT = 600;
 const char* Window::DEFAULT_TITLE = "Radix Engine";
 
 Window::Window() :
+  config(),
   width(0),
   height(0),
   window(nullptr),

--- a/source/Window.cpp
+++ b/source/Window.cpp
@@ -303,7 +303,7 @@ void Window::processEvents() {
 
 void Window::processMouseAxisEvents() {
   Vector2i mouseRelative;
-  getRelativeMouseState(&mouseRelative.x, &mouseRelative.y);
+  SDL_GetRelativeMouseState(&mouseRelative.x, &mouseRelative.y);
 
   bool nonZero = mouseRelative != Vector2i::ZERO;
 
@@ -313,15 +313,15 @@ void Window::processMouseAxisEvents() {
       d.get().dispatch(mae);
     }
   }
-
+ 
   lastNonZero = nonZero;
 }
 
 void Window::processControllerStickEvents() {
   for (int i = 0; i < 2; ++i) {
     Vector2i currentStickState;
-    currentStickState.x = SDL_GameControllerGetAxis(controller, SDL_GameControllerAxis(2*i));
-    currentStickState.y = SDL_GameControllerGetAxis(controller, SDL_GameControllerAxis(2*i + 1));
+    currentStickState.x = SDL_GameControllerGetAxis(controller, (SDL_GameControllerAxis)(2*i));
+    currentStickState.y = SDL_GameControllerGetAxis(controller, (SDL_GameControllerAxis)(2*i + 1));
 
     if (currentStickState.x > controllerStickMax.at(i).x) {
       controllerStickMax.at(i).x = currentStickState.x;
@@ -568,18 +568,11 @@ bool Window::isMouseButtonDown(const int &button) {
   return this->mouseButtonStates[button];
 }
 
-float Window::getRelativeMouseAxisValue(const int &axis) { /*
-  if (axis == int(MouseAxis::MOUSE_AXIS_X)) {
-    return (float)mouseRelativeX;
-  } else if (axis == int(MouseAxis::MOUSE_AXIS_Y)) {
-    return (float)mouseRelativeY;
-  } else {
-    return 0;
-  }*/
-}
+Vector2f Window::getRelativeMouseAxisValue() {
+  Vector2i mouseRelative;
+  SDL_GetRelativeMouseState(&mouseRelative.x, &mouseRelative.y);
 
-void Window::getRelativeMouseState(int *dx, int *dy) {
-  SDL_GetRelativeMouseState(dx, dy);
+  return Vector2f(mouseRelative);
 }
 
 std::string Window::getCharBuffer() {

--- a/source/core/math/Vector2i.cpp
+++ b/source/core/math/Vector2i.cpp
@@ -1,0 +1,16 @@
+#include <radix/core/math/Vector2i.hpp>
+
+#include <sstream>
+
+namespace radix {
+
+const Vector2i Vector2i::ZERO(0, 0);
+const Vector2i Vector2i::UP(0, 1);
+
+std::string Vector2i::str() const {
+  std::stringstream ss;
+  ss << "(" << x << ", " << y << ")";
+  return ss.str();
+}
+
+} /* namespace radix */

--- a/source/entities/Player.cpp
+++ b/source/entities/Player.cpp
@@ -48,10 +48,10 @@ static const std::array<const std::string, 6> PLAYER_FOOT_SOUND = {{
 Player::Player(const CreationParams &cp) :
   Entity(cp),
   m_btGpCallbacks(this),
+  stepCounter(0),
   flying(false),
   noclip(false),
   frozen(false),
-  stepCounter(0),
   attemptJump(false) {
 
   setScale(PLAYER_SIZE);

--- a/source/entities/Player.cpp
+++ b/source/entities/Player.cpp
@@ -48,11 +48,11 @@ static const std::array<const std::string, 6> PLAYER_FOOT_SOUND = {{
 Player::Player(const CreationParams &cp) :
   Entity(cp),
   m_btGpCallbacks(this),
-  stepCounter(0),
   flying(false),
   noclip(false),
   frozen(false),
-  attemptJump(false) {
+  attemptJump(false),
+  stepCounter(0) {
 
   setScale(PLAYER_SIZE);
 

--- a/source/env/Config.cpp
+++ b/source/env/Config.cpp
@@ -1,22 +1,59 @@
 #include <radix/env/Config.hpp>
 
+#include <string>
 #include <cstring>
 #include <fstream>
+#include <vector>
+#include <array>
 
 #include <radix/env/Environment.hpp>
+#include <radix/env/Util.hpp>
+#include <radix/input/InputManager.hpp>
+#include <radix/input/InputSource.hpp>
 
 namespace radix {
+
+const std::vector<std::vector<Bind>> Config::defaultBindings = {
+  {Bind()},
+  {Bind(InputManager::PLAYER_LOOK_ANALOGUE, Bind::MOUSE_AXIS, 0, 1.0f)},
+  {Bind(InputManager::PLAYER_JUMP, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("Space"))},
+  {Bind(InputManager::PLAYER_PORTAL_0, Bind::MOUSE_BUTTON, (int)InputSource::MouseButton::Left)},
+  {Bind(InputManager::PLAYER_PORTAL_1, Bind::MOUSE_BUTTON, (int)InputSource::MouseButton::Right)},
+  {Bind(InputManager::PLAYER_FORWARD, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("W"))},
+  {Bind(InputManager::PLAYER_BACK, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("S"))},
+  {Bind(InputManager::PLAYER_LEFT, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("A"))},
+  {Bind(InputManager::PLAYER_RIGHT, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("D"))},
+  {Bind(InputManager::GAME_PAUSE, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("Escape"))},
+  {Bind(InputManager::GAME_QUIT, Bind::KEYBOARD, InputSource::keyboardGetKeyFromString("Q"))}
+};
+
+std::string Config::actionToString(const int &action) {
+  switch (InputManager::Action(action)) {
+    case InputManager::PLAYER_JUMP :          return "jump";
+    case InputManager::PLAYER_PORTAL_0 :      return "portal_0";
+    case InputManager::PLAYER_PORTAL_1 :      return "portal_1";
+    case InputManager::PLAYER_MOVE_ANALOGUE : return "move_analogue";
+    case InputManager::PLAYER_LOOK_ANALOGUE : return "look_analogue";
+    case InputManager::PLAYER_FORWARD :       return "forward";
+    case InputManager::PLAYER_BACK :          return "back";
+    case InputManager::PLAYER_LEFT :          return "left";
+    case InputManager::PLAYER_RIGHT :         return "right";
+    case InputManager::GAME_PAUSE :           return "pause";
+    case InputManager::GAME_QUIT :            return "quit";
+    case InputManager::ACTION_INVALID :
+    case InputManager::ACTION_MAX :
+    default :                             return "";
+  }
+}
 
 Config::Config() :
   loaded(false),
   ignoreGlVersion(false),
   consoleEnabled(false),
-  flyingEnabled(false),
   profilerEnabled(false),
   debugViewEnabled(false),
-  screen(0) {
-}
-
+  bindings(InputManager::ACTION_MAX, std::vector<Bind>()),
+  screen(0) {}
 
 void Config::load() {
   std::string err;
@@ -39,12 +76,14 @@ void Config::load() {
   this->loadVideoSettings(configJson["video"]);
   this->loadSoundSettings(configJson["sound"]);
   this->loadMouseSettings(configJson["mouse"]);
+  this->loadControllerSettings(configJson["controller"]);
+  this->loadKeyboardSettings(configJson["keyboard"]);
+  //this->loadDefaultBindings();
   this->loadLoglevelSettings(configJson["logging"]);
 
   const Json &debug = configJson["debug"];
   glContextEnableDebug = debug["gl_context_debug"].bool_value();
   profilerEnabled = debug["profiler"]["enable"].bool_value();
-  flyingEnabled = debug["flying"]["enable"].bool_value();
   debugViewEnabled = debug["wireframes"]["enable"].bool_value();
   loaded = true;
 }
@@ -61,18 +100,110 @@ void Config::loadVideoSettings(const Json &json) {
   height          = json["height"].number_value();
   recursivePortal = json["recursive_portal"].number_value();
   screen          = json["screen"].number_value();
-
 }
 
 void Config::loadSoundSettings(const Json &json) {
   sound = json["enable"].bool_value();
-
 }
 
 void Config::loadMouseSettings(const Json &json) {
-  sensitivity        = json["sensitivity"].number_value();
+  mouseSensitivity   = json["sensitivity"].number_value() / 500.0f;
   hidePortalsByClick = json["hide_portals_by_click"].bool_value();
   cursorVisibility   = json["cursor_visibility"].bool_value();
+
+  for (int action = 0; action < int(InputManager::Action::ACTION_MAX); ++action) {
+    std::string actionStr = actionToString(action);
+    
+    for (int index = 0; index < 5; ++index) {
+      std::string buttonStr = json["bindings"][actionStr][index].string_value();
+      if (buttonStr == "") {
+        break;
+      } else {
+        int button = InputSource::mouseGetButtonFromString(buttonStr);
+        bool axis = buttonStr == "mouse_move";
+
+        if (button != -1) {
+          Bind bind(action, Bind::MOUSE_BUTTON, button);
+          bindings[action].push_back(bind);
+          Util::Log(Info, "Config") << buttonStr << button << " bound to " << actionStr;
+        } else if (axis) {
+          Bind bind(action, Bind::MOUSE_AXIS, 0, mouseSensitivity, 0);
+          bindings[action].push_back(bind);
+          Util::Log(Info, "Config") << buttonStr << " bound to " << actionStr << " with sensitivity " << mouseSensitivity;
+        } else {
+          Util::Log(Info, "Config") << buttonStr << "is an invalid control name";
+        }
+      }
+    }
+  }
+}
+
+void Config::loadKeyboardSettings(const Json &json) {
+  for (int action = 0; action < InputManager::ACTION_MAX; ++action) {
+    std::string actionStr = actionToString(action);
+
+    for (int index = 0; index < 5; ++index) {
+      std::string keyStr = json["bindings"][actionStr][index].string_value();
+      if (keyStr == "") {
+        break;
+      } else {
+        int key = InputSource::keyboardGetKeyFromString(keyStr);
+
+        if (key > 0) {
+          Bind bind(action, Bind::KEYBOARD, key);
+          bindings[action].push_back(bind);
+          Util::Log(Info, "Config") << keyStr << " bound to " << actionStr;
+        } else {
+          Util::Log(Info, "Config") << keyStr << "is an invalid control name";
+        }
+      }
+    }
+  }
+}
+
+void Config::loadControllerSettings(const Json &json) {
+  for (int action = 0; action < int(InputManager::Action::ACTION_MAX); ++action) {
+    std::string actionStr = actionToString(action);
+    
+    for (int index = 0; index < 5; ++index) {
+      std::string buttonStr = json["bindings"][actionStr][index].string_value();
+      if (buttonStr == "") {
+        break;
+      } else {
+        int button  = InputSource::gameControllerGetButtonFromString(buttonStr);
+        int axis    = InputSource::gameControllerGetAxisFromString(buttonStr);
+        int trigger = InputSource::gameControllerGetTriggerFromString(buttonStr);
+
+        if (button != -1) {
+          Bind bind(action, Bind::CONTROLLER_BUTTON, button);
+          bindings[action].push_back(bind);
+          Util::Log(Info, "Config") << buttonStr << " bound to " << actionStr;
+        } else if (axis != -1) {
+          float sensitivity = json["sensitivity"][buttonStr].number_value();
+          float deadZone = json["dead_zone"][buttonStr].number_value();
+          Bind bind(action, Bind::CONTROLLER_AXIS, axis, sensitivity, deadZone);
+          bindings[action].push_back(bind);
+          Util::Log(Info, "Config") << buttonStr << " bound to " << actionStr << " with sensitivity " << sensitivity << " and deadzone " << deadZone;
+        } else if (trigger != -1) {
+          float sensitivity = json["sensitivity"][buttonStr].number_value();
+          float actPoint = json["dead_zone"][buttonStr].number_value();
+          Bind bind(action, Bind::CONTROLLER_TRIGGER, trigger, sensitivity, actPoint);
+          bindings[action].push_back(bind);
+        } else {
+          Util::Log(Info, "Config") << buttonStr << "is an invalid control name";
+        }
+      }
+    }
+  }
+}
+
+void Config::loadDefaultBindings() {
+  for (int i(0); i < InputManager::ACTION_MAX; ++i) {
+    if (bindings[i].empty()) {
+      bindings[i] = defaultBindings[i];
+      Util::Log(Info, "Config") << actionToString(i) << " set to default bind";
+    }
+  }
 }
 
 void Config::loadLoglevelSettings(const Json &json) {
@@ -95,3 +226,4 @@ void Config::loadLoglevelSettings(const Json &json) {
 }
 
 } /* namespace radix */
+

--- a/source/env/Config.cpp
+++ b/source/env/Config.cpp
@@ -50,6 +50,7 @@ Config::Config() :
   loaded(false),
   ignoreGlVersion(false),
   consoleEnabled(false),
+  flyingEnabled(false),
   profilerEnabled(false),
   debugViewEnabled(false),
   bindings(InputManager::ACTION_MAX, std::vector<Bind>()),
@@ -78,12 +79,13 @@ void Config::load() {
   this->loadMouseSettings(configJson["mouse"]);
   this->loadControllerSettings(configJson["controller"]);
   this->loadKeyboardSettings(configJson["keyboard"]);
-  //this->loadDefaultBindings();
+  this->loadDefaultBindings();
   this->loadLoglevelSettings(configJson["logging"]);
 
   const Json &debug = configJson["debug"];
   glContextEnableDebug = debug["gl_context_debug"].bool_value();
   profilerEnabled = debug["profiler"]["enable"].bool_value();
+  flyingEnabled = debug["flying"]["enable"].bool_value();
   debugViewEnabled = debug["wireframes"]["enable"].bool_value();
   loaded = true;
 }

--- a/source/env/Config.cpp
+++ b/source/env/Config.cpp
@@ -42,15 +42,21 @@ std::string Config::actionToString(const int &action) {
     case InputManager::GAME_QUIT :            return "quit";
     case InputManager::ACTION_INVALID :
     case InputManager::ACTION_MAX :
-    default :                             return "";
+    default :                                 return "";
   }
 }
 
 Config::Config() :
   loaded(false),
-  ignoreGlVersion(false),
-  consoleEnabled(false),
+  fullscreen(false),
+  sound(false),
+  vsync(false),
   flyingEnabled(false),
+  hidePortalsByClick(false),
+  cursorVisibility(false),
+  ignoreGlVersion(false),
+  glContextEnableDebug(false),
+  consoleEnabled(false),
   profilerEnabled(false),
   debugViewEnabled(false),
   bindings(InputManager::ACTION_MAX, std::vector<Bind>()),
@@ -85,7 +91,6 @@ void Config::load() {
   const Json &debug = configJson["debug"];
   glContextEnableDebug = debug["gl_context_debug"].bool_value();
   profilerEnabled = debug["profiler"]["enable"].bool_value();
-  flyingEnabled = debug["flying"]["enable"].bool_value();
   debugViewEnabled = debug["wireframes"]["enable"].bool_value();
   loaded = true;
 }

--- a/source/input/Channel.cpp
+++ b/source/input/Channel.cpp
@@ -11,7 +11,7 @@ namespace radix {
 template<class T>
 void Channel<T>::init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds) {
   if (this->listeners.empty()) {
-    throw Exception::Error("Channel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+    throw Exception::Error("Channel", "Tried to initialise channel, id: " + std::to_string(id) + ", without a listener");
   }
 
   this->setId(id);

--- a/source/input/Channel.cpp
+++ b/source/input/Channel.cpp
@@ -1,0 +1,173 @@
+#include <radix/input/Channel.hpp>
+
+#include <radix/core/diag/Throwables.hpp>
+#include <radix/input/InputSource.hpp>
+#include <radix/input/InputManager.hpp>
+
+#include <cstdlib>
+
+namespace radix {
+
+template<class T>
+void Channel<T>::init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds) {
+	if (this->listeners.empty()) {
+		throw Exception::Error("Channel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+	}
+
+	this->setId(id);
+
+	if (InputManager::isActionDigital(id)) {
+		this->setDigital(0.5f);
+
+		if (id == InputManager::PLAYER_JUMP) {
+			this->setAutoZero();
+		}
+	} else {
+		this->setAnalogue(0.0f);
+	}
+
+	for (int i = 0; i < (int)binds.size(); ++i) {
+		this->subChannels.push_back(SubChannel<T>(this));
+	}
+	//these have to be separate for some reason
+	for (int i = 0; i < (int)binds.size(); ++i) {
+		this->subChannels[i].init(i, event, binds[i]);
+	}
+}
+
+template<class T>
+void Channel<T>::channelChanged(const int &id) {
+	this->Channel<T>::set(this->subChannels.at(id).SubChannel<T>::get());
+}
+
+template<class T>
+void SubChannel<T>::init(const int &id, EventDispatcher &event, const Bind& bind) {
+	if (this->listeners.empty()) {
+		throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+	}
+
+	this->setId(id);
+	this->bind = bind;
+	this->setSensitivity(bind.sensitivity);
+
+	if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
+		this->setDigital(bind.actPoint);
+	} else {
+		this->setAnalogue(bind.deadZone);
+		this->setBound(1.0f);
+	}
+
+	switch (bind.inputType) {
+
+	case Bind::KEYBOARD: {
+		this->callbacks[0] = event.addObserver(InputSource::KeyPressedEvent::Type, [this](const radix::Event& event) {
+				const int key = ((radix::InputSource::KeyPressedEvent &) event).key;
+				if (key == this->bind.inputCode) {
+					this->set(1.0f);
+				}
+			});
+
+		this->callbacks[1] = event.addObserver(InputSource::KeyReleasedEvent::Type, [this](const radix::Event& event) {
+				const int key = ((radix::InputSource::KeyReleasedEvent &) event).key;
+				if (key == this->bind.inputCode) {
+					this->set(0.0f);
+				}
+			});
+		break;
+	}
+	case Bind::MOUSE_BUTTON: {
+		this->callbacks[0] = event.addObserver(InputSource::MouseButtonPressedEvent::Type, [this](const radix::Event& event) {
+				const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
+				if (button == this->bind.inputCode) {
+					this->set((T)1.0f);
+				}
+			});
+
+		this->callbacks[1] = event.addObserver(InputSource::MouseButtonReleasedEvent::Type, [this](const radix::Event& event) {
+				const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
+				if (button == this->bind.inputCode) {
+					this->set((T)0.0f);
+				}
+			});
+		break;
+	}
+	case Bind::CONTROLLER_BUTTON: {
+		this->callbacks[0] = event.addObserver(InputSource::ControllerButtonPressedEvent::Type, [this](const radix::Event& event) {
+				const int button = ((radix::InputSource::ControllerButtonPressedEvent &) event).button;
+				if (button == this->bind.inputCode) {
+					this->set((T)1.0f);
+				}
+			});
+
+		this->callbacks[1] = event.addObserver(InputSource::ControllerButtonReleasedEvent::Type, [this](const radix::Event& event) {
+				const int button = ((radix::InputSource::ControllerButtonReleasedEvent &) event).button;
+				if (button == this->bind.inputCode) {
+					this->set((T)0.0f);
+				}
+			});
+		break;
+	}
+	case Bind::CONTROLLER_TRIGGER: {
+		this->callbacks[0] = event.addObserver(InputSource::ControllerTriggerEvent::Type, [this](const radix::Event& event) {
+				const int trigger = ((radix::InputSource::ControllerTriggerEvent &) event).trigger;
+				const float value = ((radix::InputSource::ControllerTriggerEvent &) event).value;
+				if (trigger == this->bind.inputCode) {
+					this->set((T)value);
+				}
+			});
+		break;
+	}
+	}
+}
+
+template<>
+void SubChannel<Vector2f>::init(const int &id, EventDispatcher &event, const Bind& bind) {
+	if (this->listeners.empty()) {
+		throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+	}
+
+	this->setId(id);
+	this->bind = bind;
+	this->setSensitivity(bind.sensitivity);
+	if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
+	} else {
+		if (bind.inputType == Bind::CONTROLLER_AXIS) {
+			setAnalogue(bind.deadZone);
+			setBound(0.8f);
+		}
+		if (bind.inputType == Bind::MOUSE_AXIS) {
+			setAnalogue(0.0f);
+			setAutoZero();
+		}
+	}
+
+	switch (bind.inputType) {
+	case Bind::MOUSE_AXIS: {
+		this->callbacks[0] = event.addObserver(InputSource::MouseAxisEvent::Type, [this](const radix::Event& event) {
+						const Vector2f value = ((radix::InputSource::MouseAxisEvent &) event).value;
+		
+						this->set(value);
+					});
+		break;
+	}
+	case Bind::CONTROLLER_AXIS: {
+		this->callbacks[1] = event.addObserver(InputSource::ControllerAxisEvent::Type, [this](const radix::Event& event) {
+				const int axis = ((radix::InputSource::ControllerAxisEvent &) event).axis;
+				const Vector2f value = ((radix::InputSource::ControllerAxisEvent &) event).value;
+
+				if (axis == this->bind.inputCode) {
+					this->SubChannel<Vector2f>::set(value);
+				}
+			});
+		break;
+	}
+	}
+}
+
+template class Channel<float>;
+template class Channel<Vector2f>;
+
+template class SubChannel<float>;
+template class SubChannel<Vector2f>;
+
+}

--- a/source/input/Channel.cpp
+++ b/source/input/Channel.cpp
@@ -10,158 +10,158 @@ namespace radix {
   
 template<class T>
 void Channel<T>::init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds) {
-	if (this->listeners.empty()) {
-		throw Exception::Error("Channel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
-	}
+  if (this->listeners.empty()) {
+    throw Exception::Error("Channel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+  }
 
-	this->setId(id);
+  this->setId(id);
 
-	if (InputManager::isActionDigital(id)) {
-		this->setDigital(0.5f);
+  if (InputManager::isActionDigital(id)) {
+    this->setDigital(0.5f);
 
-		if (id == InputManager::PLAYER_JUMP) {
-			this->setAutoZero();
-		}
-	} else {
-		this->setAnalogue(0.0f);
-	}
+    if (id == InputManager::PLAYER_JUMP) {
+      this->setAutoZero();
+    }
+  } else {
+    this->setAnalogue(0.0f);
+  }
 
-	for (int i = 0; i < (int)binds.size(); ++i) {
-		this->subChannels.push_back(SubChannel<T>(this));
-	}
-	//these have to be separate for some reason
-	for (int i = 0; i < (int)binds.size(); ++i) {
-		this->subChannels[i].init(i, event, binds[i]);
-	}
+  for (int i = 0; i < (int)binds.size(); ++i) {
+    this->subChannels.push_back(SubChannel<T>(this));
+  }
+  //these have to be separate for some reason
+  for (int i = 0; i < (int)binds.size(); ++i) {
+    this->subChannels[i].init(i, event, binds[i]);
+  }
 }
 
 template<class T>
 void Channel<T>::channelChanged(const int &id) {
-	this->Channel<T>::set(this->subChannels.at(id).SubChannel<T>::get());
+  this->Channel<T>::set(this->subChannels.at(id).SubChannel<T>::get());
 }
 
 template<class T>
 void SubChannel<T>::init(const int &id, EventDispatcher &event, const Bind& bind) {
-	if (this->listeners.empty()) {
-		throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
-	}
+  if (this->listeners.empty()) {
+    throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+  }
 
-	this->setId(id);
-	this->bind = bind;
-	this->setSensitivity(bind.sensitivity);
+  this->setId(id);
+  this->bind = bind;
+  this->setSensitivity(bind.sensitivity);
 
-	if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
-		this->setDigital(bind.actPoint);
-	} else {
-		this->setAnalogue(bind.deadZone);
-		this->setBound(1.0f);
-	}
+  if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
+    this->setDigital(bind.actPoint);
+  } else {
+    this->setAnalogue(bind.deadZone);
+    this->setBound(1.0f);
+  }
 
-	switch (bind.inputType) {
+  switch (bind.inputType) {
 
-	case Bind::KEYBOARD: {
-		this->callbacks[0] = event.addObserver(InputSource::KeyPressedEvent::Type, [this](const radix::Event& event) {
-				const int key = ((radix::InputSource::KeyPressedEvent &) event).key;
-				if (key == this->bind.inputCode) {
-					this->set(1.0f);
-				}
-			});
+  case Bind::KEYBOARD: {
+    this->callbacks[0] = event.addObserver(InputSource::KeyPressedEvent::Type, [this](const radix::Event& event) {
+        const int key = ((radix::InputSource::KeyPressedEvent &) event).key;
+        if (key == this->bind.inputCode) {
+          this->set(1.0f);
+        }
+      });
 
-		this->callbacks[1] = event.addObserver(InputSource::KeyReleasedEvent::Type, [this](const radix::Event& event) {
-				const int key = ((radix::InputSource::KeyReleasedEvent &) event).key;
-				if (key == this->bind.inputCode) {
-					this->set(0.0f);
-				}
-			});
-		break;
-	}
-	case Bind::MOUSE_BUTTON: {
-		this->callbacks[0] = event.addObserver(InputSource::MouseButtonPressedEvent::Type, [this](const radix::Event& event) {
-				const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
-				if (button == this->bind.inputCode) {
-					this->set((T)1.0f);
-				}
-			});
+    this->callbacks[1] = event.addObserver(InputSource::KeyReleasedEvent::Type, [this](const radix::Event& event) {
+        const int key = ((radix::InputSource::KeyReleasedEvent &) event).key;
+        if (key == this->bind.inputCode) {
+          this->set(0.0f);
+        }
+      });
+    break;
+  }
+  case Bind::MOUSE_BUTTON: {
+    this->callbacks[0] = event.addObserver(InputSource::MouseButtonPressedEvent::Type, [this](const radix::Event& event) {
+        const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
+        if (button == this->bind.inputCode) {
+          this->set((T)1.0f);
+        }
+      });
 
-		this->callbacks[1] = event.addObserver(InputSource::MouseButtonReleasedEvent::Type, [this](const radix::Event& event) {
-				const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
-				if (button == this->bind.inputCode) {
-					this->set((T)0.0f);
-				}
-			});
-		break;
-	}
-	case Bind::CONTROLLER_BUTTON: {
-		this->callbacks[0] = event.addObserver(InputSource::ControllerButtonPressedEvent::Type, [this](const radix::Event& event) {
-				const int button = ((radix::InputSource::ControllerButtonPressedEvent &) event).button;
-				if (button == this->bind.inputCode) {
-					this->set((T)1.0f);
-				}
-			});
+    this->callbacks[1] = event.addObserver(InputSource::MouseButtonReleasedEvent::Type, [this](const radix::Event& event) {
+        const int button = (int)((radix::InputSource::MouseButtonPressedEvent &) event).button;
+        if (button == this->bind.inputCode) {
+          this->set((T)0.0f);
+        }
+      });
+    break;
+  }
+  case Bind::CONTROLLER_BUTTON: {
+    this->callbacks[0] = event.addObserver(InputSource::ControllerButtonPressedEvent::Type, [this](const radix::Event& event) {
+        const int button = ((radix::InputSource::ControllerButtonPressedEvent &) event).button;
+        if (button == this->bind.inputCode) {
+          this->set((T)1.0f);
+        }
+      });
 
-		this->callbacks[1] = event.addObserver(InputSource::ControllerButtonReleasedEvent::Type, [this](const radix::Event& event) {
-				const int button = ((radix::InputSource::ControllerButtonReleasedEvent &) event).button;
-				if (button == this->bind.inputCode) {
-					this->set((T)0.0f);
-				}
-			});
-		break;
-	}
-	case Bind::CONTROLLER_TRIGGER: {
-		this->callbacks[0] = event.addObserver(InputSource::ControllerTriggerEvent::Type, [this](const radix::Event& event) {
-				const int trigger = ((radix::InputSource::ControllerTriggerEvent &) event).trigger;
-				const float value = ((radix::InputSource::ControllerTriggerEvent &) event).value;
-				if (trigger == this->bind.inputCode) {
-					this->set((T)value);
-				}
-			});
-		break;
-	}
-	}
+    this->callbacks[1] = event.addObserver(InputSource::ControllerButtonReleasedEvent::Type, [this](const radix::Event& event) {
+        const int button = ((radix::InputSource::ControllerButtonReleasedEvent &) event).button;
+        if (button == this->bind.inputCode) {
+          this->set((T)0.0f);
+        }
+      });
+    break;
+  }
+  case Bind::CONTROLLER_TRIGGER: {
+    this->callbacks[0] = event.addObserver(InputSource::ControllerTriggerEvent::Type, [this](const radix::Event& event) {
+        const int trigger = ((radix::InputSource::ControllerTriggerEvent &) event).trigger;
+        const float value = ((radix::InputSource::ControllerTriggerEvent &) event).value;
+        if (trigger == this->bind.inputCode) {
+          this->set((T)value);
+        }
+      });
+    break;
+  }
+  }
 }
 
 template<>
 void SubChannel<Vector2f>::init(const int &id, EventDispatcher &event, const Bind& bind) {
-	if (this->listeners.empty()) {
-		throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
-	}
+  if (this->listeners.empty()) {
+    throw Exception::Error("SubChannel", "Tried to initialise sub-channel, id: " + std::to_string(id) + ", without a listener");
+  }
 
-	this->setId(id);
-	this->bind = bind;
-	this->setSensitivity(bind.sensitivity);
-	if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
-	} else {
-		if (bind.inputType == Bind::CONTROLLER_AXIS) {
-			setAnalogue(bind.deadZone);
-			setBound(0.8f);
-		}
-		if (bind.inputType == Bind::MOUSE_AXIS) {
-			setAnalogue(0.0f);
-			setAutoZero();
-		}
-	}
+  this->setId(id);
+  this->bind = bind;
+  this->setSensitivity(bind.sensitivity);
+  if (InputManager::isActionDigital(bind.action) or Bind::isInputTypeDigital(bind.inputType)) {
+  } else {
+    if (bind.inputType == Bind::CONTROLLER_AXIS) {
+      setAnalogue(bind.deadZone);
+      setBound(0.8f);
+    }
+    if (bind.inputType == Bind::MOUSE_AXIS) {
+      setAnalogue(0.0f);
+      setAutoZero();
+    }
+  }
 
-	switch (bind.inputType) {
-	case Bind::MOUSE_AXIS: {
-		this->callbacks[0] = event.addObserver(InputSource::MouseAxisEvent::Type, [this](const radix::Event& event) {
-						const Vector2f value = ((radix::InputSource::MouseAxisEvent &) event).value;
-		
-						this->set(value);
-					});
-		break;
-	}
-	case Bind::CONTROLLER_AXIS: {
-		this->callbacks[1] = event.addObserver(InputSource::ControllerAxisEvent::Type, [this](const radix::Event& event) {
-				const int axis = ((radix::InputSource::ControllerAxisEvent &) event).axis;
-				const Vector2f value = ((radix::InputSource::ControllerAxisEvent &) event).value;
+  switch (bind.inputType) {
+  case Bind::MOUSE_AXIS: {
+    this->callbacks[0] = event.addObserver(InputSource::MouseAxisEvent::Type, [this](const radix::Event& event) {
+            const Vector2f value = ((radix::InputSource::MouseAxisEvent &) event).value;
+    
+            this->set(value);
+          });
+    break;
+  }
+  case Bind::CONTROLLER_AXIS: {
+    this->callbacks[1] = event.addObserver(InputSource::ControllerAxisEvent::Type, [this](const radix::Event& event) {
+        const int axis = ((radix::InputSource::ControllerAxisEvent &) event).axis;
+        const Vector2f value = ((radix::InputSource::ControllerAxisEvent &) event).value;
 
-				if (axis == this->bind.inputCode) {
-					this->SubChannel<Vector2f>::set(value);
-				}
-			});
-		break;
-	}
-	}
+        if (axis == this->bind.inputCode) {
+          this->SubChannel<Vector2f>::set(value);
+        }
+      });
+    break;
+  }
+  }
 }
 
 template class Channel<float>;

--- a/source/input/Channel.cpp
+++ b/source/input/Channel.cpp
@@ -7,7 +7,7 @@
 #include <cstdlib>
 
 namespace radix {
-
+  
 template<class T>
 void Channel<T>::init(const int &id, EventDispatcher &event, const std::vector<Bind> &binds) {
 	if (this->listeners.empty()) {

--- a/source/input/ChannelBase.cpp
+++ b/source/input/ChannelBase.cpp
@@ -18,7 +18,7 @@ ChannelBase<T>::ChannelBase()
 		isDigital(false),
 		autoZero(false),
 		alwaysNotifyListener(false),
-	  actPoint(0),
+	  	actPoint(0),
 		value() {}
 
 template <class T>
@@ -31,7 +31,7 @@ ChannelBase<T>::ChannelBase(ChannelListener *listener)
 		isDigital(false),
 		autoZero(false),
 		alwaysNotifyListener(false),
-	  actPoint(0),
+	  	actPoint(0),
 		value() {}
 
 template <class T>

--- a/source/input/ChannelBase.cpp
+++ b/source/input/ChannelBase.cpp
@@ -10,131 +10,131 @@ namespace radix {
 
 template <class T>
 ChannelBase<T>::ChannelBase()
-		: listeners(1, nullptr),
-		id(0),
-		bound(0),
-		sensitivity(1.0f),
-		hasBound(false),
-		isDigital(false),
-		autoZero(false),
-		alwaysNotifyListener(false),
-	  	actPoint(0),
-		value() {}
+    : listeners(1, nullptr),
+    id(0),
+    bound(0),
+    sensitivity(1.0f),
+    hasBound(false),
+    isDigital(false),
+    autoZero(false),
+    alwaysNotifyListener(false),
+      actPoint(0),
+    value() {}
 
 template <class T>
 ChannelBase<T>::ChannelBase(ChannelListener *listener)
-		: listeners(1, listener),
-		id(0),
-		bound(0),
-		sensitivity(1.0f),
-		hasBound(false),
-		isDigital(false),
-		autoZero(false),
-		alwaysNotifyListener(false),
-	  	actPoint(0),
-		value() {}
+    : listeners(1, listener),
+    id(0),
+    bound(0),
+    sensitivity(1.0f),
+    hasBound(false),
+    isDigital(false),
+    autoZero(false),
+    alwaysNotifyListener(false),
+      actPoint(0),
+    value() {}
 
 template <class T>
 void ChannelBase<T>::addListener(ChannelListener* listener) {
-	for (ChannelListener* mListener: listeners) {
-		if (listener == mListener) {
-			return;
-		}
-	}
+  for (ChannelListener* mListener: listeners) {
+    if (listener == mListener) {
+      return;
+    }
+  }
 
-	listeners.push_back(listener);
+  listeners.push_back(listener);
 }
 
 template <class T>
 void ChannelBase<T>::setDigital(const float &actPoint) {
-	this->actPoint = actPoint;
-	isDigital = true;
+  this->actPoint = actPoint;
+  isDigital = true;
 }
 
 template <class T>
 void ChannelBase<T>::setAnalogue(const float &deadZone) {
-	this->deadZone = deadZone;
-	isDigital = false;
+  this->deadZone = deadZone;
+  isDigital = false;
 }
 
 template <class T>
 void ChannelBase<T>::setBound(const float &bound) {
-	this->bound = bound;
-	hasBound = true;
+  this->bound = bound;
+  hasBound = true;
 }
 
 template <class T>
 void ChannelBase<T>::set(T newValue) {
-	if (isDigital) {
-		newValue = std::abs(newValue) >= actPoint ? 1.0f : 0.0f;
-	} else {
-		newValue = std::abs(newValue) >= deadZone ? newValue : 0.0f;
+  if (isDigital) {
+    newValue = std::abs(newValue) >= actPoint ? 1.0f : 0.0f;
+  } else {
+    newValue = std::abs(newValue) >= deadZone ? newValue : 0.0f;
 
-		if (hasBound) {
-			newValue = std::abs(newValue) >= bound ? 1.0f : newValue;
-		}
-		
-		newValue *= sensitivity;
-	}
+    if (hasBound) {
+      newValue = std::abs(newValue) >= bound ? 1.0f : newValue;
+    }
+    
+    newValue *= sensitivity;
+  }
 
-	if (value != newValue or alwaysNotifyListener) {
-		value = newValue;
+  if (value != newValue or alwaysNotifyListener) {
+    value = newValue;
 
-		if (not listeners.empty()) {
-			notifyListeners();
-		}
-	} else {
-		return;
-	}
+    if (not listeners.empty()) {
+      notifyListeners();
+    }
+  } else {
+    return;
+  }
 
-	if (autoZero) {
-		value = 0.0f;
-	}
+  if (autoZero) {
+    value = 0.0f;
+  }
 }
 
 template <>
 void ChannelBase<Vector2f>::set(Vector2f newValue) {
-	if (isDigital) {
-		newValue.x = newValue.x >= actPoint ? 1.0f : 0.0f;
-		newValue.y = newValue.y >= actPoint ? 1.0f : 0.0f;
-	} else {
-		float length = newValue.length();
-		if (deadZone > 0) {
-			if (length <= deadZone) {
-				newValue = Vector2f::ZERO;
-			} else {
-				newValue *= (length - deadZone) / length;
-			}
-		}
-	
-		if (hasBound) {
-			newValue.x = std::abs(newValue.x) >= bound ? 1.0f : newValue.x;
-			newValue.y = std::abs(newValue.y) >= bound ? 1.0f : newValue.y;
-		}
+  if (isDigital) {
+    newValue.x = newValue.x >= actPoint ? 1.0f : 0.0f;
+    newValue.y = newValue.y >= actPoint ? 1.0f : 0.0f;
+  } else {
+    float length = newValue.length();
+    if (deadZone > 0) {
+      if (length <= deadZone) {
+        newValue = Vector2f::ZERO;
+      } else {
+        newValue *= (length - deadZone) / length;
+      }
+    }
+  
+    if (hasBound) {
+      newValue.x = std::abs(newValue.x) >= bound ? 1.0f : newValue.x;
+      newValue.y = std::abs(newValue.y) >= bound ? 1.0f : newValue.y;
+    }
 
-		newValue *= sensitivity;
-	}
+    newValue *= sensitivity;
+  }
 
-	if (alwaysNotifyListener or !newValue.fuzzyEqual(value, 0.0001)) {
-		value = newValue;
+  if (alwaysNotifyListener or !newValue.fuzzyEqual(value, 0.0001)) {
+    value = newValue;
 
-		if (not listeners.empty()) {
-			notifyListeners();
-		}
-	} else {
-		return;
-	}
+    if (not listeners.empty()) {
+      notifyListeners();
+    }
+  } else {
+    return;
+  }
 
-	if (false) {
-		value = Vector2f(0.0f);
-	}
+  if (false) {
+    value = Vector2f(0.0f);
+  }
 }
 
 template <class T>
 void ChannelBase<T>::notifyListeners() {
-	for (ChannelListener* listener: this->listeners) {
-		listener->channelChanged(id);
-	}
+  for (ChannelListener* listener: this->listeners) {
+    listener->channelChanged(id);
+  }
 }
 
 template class ChannelBase<float>;

--- a/source/input/ChannelBase.cpp
+++ b/source/input/ChannelBase.cpp
@@ -3,7 +3,6 @@
 #include <radix/core/math/Math.hpp>
 #include <radix/core/math/Vector2f.hpp>
 #include <radix/input/ChannelListener.hpp>
-#include <radix/env/Util.hpp>
 
 #include <cstdlib>
 
@@ -95,7 +94,6 @@ void ChannelBase<T>::set(T newValue) {
 
 template <>
 void ChannelBase<Vector2f>::set(Vector2f newValue) {
-	Util::Log(Info, "ChannelBase") << "before" << "x: " << newValue.x << " y: " << newValue.y;
 	if (isDigital) {
 		newValue.x = newValue.x >= actPoint ? 1.0f : 0.0f;
 		newValue.y = newValue.y >= actPoint ? 1.0f : 0.0f;
@@ -130,7 +128,6 @@ void ChannelBase<Vector2f>::set(Vector2f newValue) {
 	if (false) {
 		value = Vector2f(0.0f);
 	}
-	//Util::Log(Info, "ChannelBase") << "after" << "x: " << value.x << " y: " << value.y;
 }
 
 template <class T>

--- a/source/input/ChannelBase.cpp
+++ b/source/input/ChannelBase.cpp
@@ -1,0 +1,146 @@
+#include <radix/input/ChannelBase.hpp>
+
+#include <radix/core/math/Math.hpp>
+#include <radix/core/math/Vector2f.hpp>
+#include <radix/input/ChannelListener.hpp>
+#include <radix/env/Util.hpp>
+
+#include <cstdlib>
+
+namespace radix {
+
+template <class T>
+ChannelBase<T>::ChannelBase()
+		: listeners(1, nullptr),
+		id(0),
+		bound(0),
+		sensitivity(1.0f),
+		hasBound(false),
+		isDigital(false),
+		autoZero(false),
+		alwaysNotifyListener(false),
+	  actPoint(0),
+		value() {}
+
+template <class T>
+ChannelBase<T>::ChannelBase(ChannelListener *listener)
+		: listeners(1, listener),
+		id(0),
+		bound(0),
+		sensitivity(1.0f),
+		hasBound(false),
+		isDigital(false),
+		autoZero(false),
+		alwaysNotifyListener(false),
+	  actPoint(0),
+		value() {}
+
+template <class T>
+void ChannelBase<T>::addListener(ChannelListener* listener) {
+	for (ChannelListener* mListener: listeners) {
+		if (listener == mListener) {
+			return;
+		}
+	}
+
+	listeners.push_back(listener);
+}
+
+template <class T>
+void ChannelBase<T>::setDigital(const float &actPoint) {
+	this->actPoint = actPoint;
+	isDigital = true;
+}
+
+template <class T>
+void ChannelBase<T>::setAnalogue(const float &deadZone) {
+	this->deadZone = deadZone;
+	isDigital = false;
+}
+
+template <class T>
+void ChannelBase<T>::setBound(const float &bound) {
+	this->bound = bound;
+	hasBound = true;
+}
+
+template <class T>
+void ChannelBase<T>::set(T newValue) {
+	if (isDigital) {
+		newValue = std::abs(newValue) >= actPoint ? 1.0f : 0.0f;
+	} else {
+		newValue = std::abs(newValue) >= deadZone ? newValue : 0.0f;
+
+		if (hasBound) {
+			newValue = std::abs(newValue) >= bound ? 1.0f : newValue;
+		}
+		
+		newValue *= sensitivity;
+	}
+
+	if (value != newValue or alwaysNotifyListener) {
+		value = newValue;
+
+		if (not listeners.empty()) {
+			notifyListeners();
+		}
+	} else {
+		return;
+	}
+
+	if (autoZero) {
+		value = 0.0f;
+	}
+}
+
+template <>
+void ChannelBase<Vector2f>::set(Vector2f newValue) {
+	Util::Log(Info, "ChannelBase") << "before" << "x: " << newValue.x << " y: " << newValue.y;
+	if (isDigital) {
+		newValue.x = newValue.x >= actPoint ? 1.0f : 0.0f;
+		newValue.y = newValue.y >= actPoint ? 1.0f : 0.0f;
+	} else {
+		float length = newValue.length();
+		if (deadZone > 0) {
+			if (length <= deadZone) {
+				newValue = Vector2f::ZERO;
+			} else {
+				newValue *= (length - deadZone) / length;
+			}
+		}
+	
+		if (hasBound) {
+			newValue.x = std::abs(newValue.x) >= bound ? 1.0f : newValue.x;
+			newValue.y = std::abs(newValue.y) >= bound ? 1.0f : newValue.y;
+		}
+
+		newValue *= sensitivity;
+	}
+
+	if (alwaysNotifyListener or !newValue.fuzzyEqual(value, 0.0001)) {
+		value = newValue;
+
+		if (not listeners.empty()) {
+			notifyListeners();
+		}
+	} else {
+		return;
+	}
+
+	if (false) {
+		value = Vector2f(0.0f);
+	}
+	//Util::Log(Info, "ChannelBase") << "after" << "x: " << value.x << " y: " << value.y;
+}
+
+template <class T>
+void ChannelBase<T>::notifyListeners() {
+	for (ChannelListener* listener: this->listeners) {
+		listener->channelChanged(id);
+	}
+}
+
+template class ChannelBase<float>;
+template class ChannelBase<Vector2f>;
+
+}

--- a/source/input/InputManager.cpp
+++ b/source/input/InputManager.cpp
@@ -12,110 +12,110 @@
 namespace radix {
 
 InputManager::InputManager(BaseGame &game) :
-	game(game) {}
+  game(game) {}
 
 void InputManager::setConfig(const Config &config) {
-	this->config = config;
+  this->config = config;
 }
 
 void InputManager::init(EventDispatcher &event) {
-	if (not config.getBindings()[PLAYER_MOVE_ANALOGUE].empty()) {
-		analogueChannels[PLAYER_MOVE_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
-		analogueChannels[PLAYER_MOVE_ANALOGUE].init(PLAYER_MOVE_ANALOGUE, event, config.getBindings()[PLAYER_MOVE_ANALOGUE]);
-	}
+  if (not config.getBindings()[PLAYER_MOVE_ANALOGUE].empty()) {
+    analogueChannels[PLAYER_MOVE_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
+    analogueChannels[PLAYER_MOVE_ANALOGUE].init(PLAYER_MOVE_ANALOGUE, event, config.getBindings()[PLAYER_MOVE_ANALOGUE]);
+  }
 
-	analogueChannels[PLAYER_LOOK_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
-	analogueChannels[PLAYER_LOOK_ANALOGUE].init(PLAYER_LOOK_ANALOGUE, event, config.getBindings()[PLAYER_LOOK_ANALOGUE]);
+  analogueChannels[PLAYER_LOOK_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
+  analogueChannels[PLAYER_LOOK_ANALOGUE].init(PLAYER_LOOK_ANALOGUE, event, config.getBindings()[PLAYER_LOOK_ANALOGUE]);
 
-	for (int id = 2; id < ACTION_MAX; ++id) {
-		digitalChannels[id] = Channel<float>((ChannelListener*)this);
-		digitalChannels[id].init(id, event, config.getBindings()[id]);
-	}
+  for (int id = 2; id < ACTION_MAX; ++id) {
+    digitalChannels[id] = Channel<float>((ChannelListener*)this);
+    digitalChannels[id].init(id, event, config.getBindings()[id]);
+  }
 }
 
 void InputManager::channelChanged(const int &id) {
-	entities::Player& player = game.getWorld()->getPlayer();
+  entities::Player& player = game.getWorld()->getPlayer();
 
-	switch(id) {
-	case PLAYER_MOVE_ANALOGUE: {
-		Vector2f movement = analogueChannels[PLAYER_MOVE_ANALOGUE].get();
-		player.move(movement);
-		break;
-	}
-	case PLAYER_LOOK_ANALOGUE: {
-		Vector2f heading = analogueChannels[PLAYER_LOOK_ANALOGUE].get();
-		player.changeHeading(heading);
-		break;
-	}
-	case PLAYER_JUMP: {
-		if (digitalChannels[PLAYER_JUMP].get()) {
-			player.jump();
-		}
-		break;
-	}
-	case PLAYER_PORTAL_0: {
-		//
-	}
-	case PLAYER_PORTAL_1: {
-		//
-	}
-	case PLAYER_FORWARD:
-	case PLAYER_BACK: {
-		float moveY = digitalChannels[PLAYER_BACK].get() - digitalChannels[PLAYER_FORWARD].get();
-		player.moveY(moveY);
-		break;
-	}
-	case PLAYER_LEFT:
-	case PLAYER_RIGHT: {
-		float moveX = digitalChannels[PLAYER_RIGHT].get() - digitalChannels[PLAYER_LEFT].get();
-		player.moveX(moveX);
-		break;
-	}
-	case GAME_PAUSE: {
+  switch(id) {
+  case PLAYER_MOVE_ANALOGUE: {
+    Vector2f movement = analogueChannels[PLAYER_MOVE_ANALOGUE].get();
+    player.move(movement);
+    break;
+  }
+  case PLAYER_LOOK_ANALOGUE: {
+    Vector2f heading = analogueChannels[PLAYER_LOOK_ANALOGUE].get();
+    player.changeHeading(heading);
+    break;
+  }
+  case PLAYER_JUMP: {
+    if (digitalChannels[PLAYER_JUMP].get()) {
+      player.jump();
+    }
+    break;
+  }
+  case PLAYER_PORTAL_0: {
+    //
+  }
+  case PLAYER_PORTAL_1: {
+    //
+  }
+  case PLAYER_FORWARD:
+  case PLAYER_BACK: {
+    float moveY = digitalChannels[PLAYER_BACK].get() - digitalChannels[PLAYER_FORWARD].get();
+    player.moveY(moveY);
+    break;
+  }
+  case PLAYER_LEFT:
+  case PLAYER_RIGHT: {
+    float moveX = digitalChannels[PLAYER_RIGHT].get() - digitalChannels[PLAYER_LEFT].get();
+    player.moveX(moveX);
+    break;
+  }
+  case GAME_PAUSE: {
 
-	}
-	case GAME_QUIT: {
-		if (digitalChannels[GAME_QUIT].get()) {
-			game.close();
-		}
-		break;
-	}
-	default: {
-		return;
-	}
-	}
+  }
+  case GAME_QUIT: {
+    if (digitalChannels[GAME_QUIT].get()) {
+      game.close();
+    }
+    break;
+  }
+  default: {
+    return;
+  }
+  }
 }
 
 Vector2f InputManager::getPlayerMovementVector() const {
-	Vector2f movement = analogueChannels.at(PLAYER_MOVE_ANALOGUE).get();
-	movement.x += digitalChannels.at(PLAYER_RIGHT).get() - digitalChannels.at(PLAYER_LEFT).get();
-	movement.y += digitalChannels.at(PLAYER_BACK).get() - digitalChannels.at(PLAYER_FORWARD).get();
-	return movement;
+  Vector2f movement = analogueChannels.at(PLAYER_MOVE_ANALOGUE).get();
+  movement.x += digitalChannels.at(PLAYER_RIGHT).get() - digitalChannels.at(PLAYER_LEFT).get();
+  movement.y += digitalChannels.at(PLAYER_BACK).get() - digitalChannels.at(PLAYER_FORWARD).get();
+  return movement;
 }
 
 bool InputManager::isActionDigital(const int &act) {
-	switch(act) {
-	case PLAYER_JUMP:
-	case PLAYER_PORTAL_0:
-	case PLAYER_PORTAL_1:
-	case PLAYER_FORWARD:
-	case PLAYER_BACK:
-	case PLAYER_LEFT:
-	case PLAYER_RIGHT :
-	case GAME_PAUSE :
-	case GAME_QUIT : {
-		return true;
-		break;
-	}
-	case PLAYER_MOVE_ANALOGUE:
-	case PLAYER_LOOK_ANALOGUE:
-	case ACTION_MAX :
-	case ACTION_INVALID :
-	default : {
-		return false;
-		break;
-	}
-	}
+  switch(act) {
+  case PLAYER_JUMP:
+  case PLAYER_PORTAL_0:
+  case PLAYER_PORTAL_1:
+  case PLAYER_FORWARD:
+  case PLAYER_BACK:
+  case PLAYER_LEFT:
+  case PLAYER_RIGHT :
+  case GAME_PAUSE :
+  case GAME_QUIT : {
+    return true;
+    break;
+  }
+  case PLAYER_MOVE_ANALOGUE:
+  case PLAYER_LOOK_ANALOGUE:
+  case ACTION_MAX :
+  case ACTION_INVALID :
+  default : {
+    return false;
+    break;
+  }
+  }
 }
 
 }

--- a/source/input/InputManager.cpp
+++ b/source/input/InputManager.cpp
@@ -1,0 +1,121 @@
+#include <radix/input/InputManager.hpp>
+
+#include <cstdlib>
+
+#include <radix/env/Config.hpp>
+#include <radix/input/Bind.hpp>
+#include <radix/core/diag/Throwables.hpp>
+#include <radix/core/event/EventDispatcher.hpp>
+#include <radix/entities/Player.hpp>
+#include <radix/BaseGame.hpp>
+
+namespace radix {
+
+InputManager::InputManager(BaseGame &game) :
+	game(game) {}
+
+void InputManager::setConfig(const Config &config) {
+	this->config = config;
+}
+
+void InputManager::init(EventDispatcher &event) {
+	if (not config.getBindings()[PLAYER_MOVE_ANALOGUE].empty()) {
+		analogueChannels[PLAYER_MOVE_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
+		analogueChannels[PLAYER_MOVE_ANALOGUE].init(PLAYER_MOVE_ANALOGUE, event, config.getBindings()[PLAYER_MOVE_ANALOGUE]);
+	}
+
+	analogueChannels[PLAYER_LOOK_ANALOGUE] = Channel<Vector2f>((ChannelListener*)this);
+	analogueChannels[PLAYER_LOOK_ANALOGUE].init(PLAYER_LOOK_ANALOGUE, event, config.getBindings()[PLAYER_LOOK_ANALOGUE]);
+
+	for (int id = 2; id < ACTION_MAX; ++id) {
+		digitalChannels[id] = Channel<float>((ChannelListener*)this);
+		digitalChannels[id].init(id, event, config.getBindings()[id]);
+	}
+}
+
+void InputManager::channelChanged(const int &id) {
+	entities::Player& player = game.getWorld()->getPlayer();
+
+	switch(id) {
+	case PLAYER_MOVE_ANALOGUE: {
+		Vector2f movement = analogueChannels[PLAYER_MOVE_ANALOGUE].get();
+		player.move(movement);
+		break;
+	}
+	case PLAYER_LOOK_ANALOGUE: {
+		Vector2f heading = analogueChannels[PLAYER_LOOK_ANALOGUE].get();
+		player.changeHeading(heading);
+		break;
+	}
+	case PLAYER_JUMP: {
+		if (digitalChannels[PLAYER_JUMP].get()) {
+			player.jump();
+		}
+		break;
+	}
+	case PLAYER_PORTAL_0: {
+		//
+	}
+	case PLAYER_PORTAL_1: {
+		//
+	}
+	case PLAYER_FORWARD:
+	case PLAYER_BACK: {
+		float moveY = digitalChannels[PLAYER_BACK].get() - digitalChannels[PLAYER_FORWARD].get();
+		player.moveY(moveY);
+		break;
+	}
+	case PLAYER_LEFT:
+	case PLAYER_RIGHT: {
+		float moveX = digitalChannels[PLAYER_RIGHT].get() - digitalChannels[PLAYER_LEFT].get();
+		player.moveX(moveX);
+		break;
+	}
+	case GAME_PAUSE: {
+
+	}
+	case GAME_QUIT: {
+		if (digitalChannels[GAME_QUIT].get()) {
+			game.close();
+		}
+		break;
+	}
+	default: {
+		return;
+	}
+	}
+}
+
+Vector2f InputManager::getPlayerMovementVector() const {
+	Vector2f movement = analogueChannels.at(PLAYER_MOVE_ANALOGUE).get();
+	movement.x += digitalChannels.at(PLAYER_RIGHT).get() - digitalChannels.at(PLAYER_LEFT).get();
+	movement.y += digitalChannels.at(PLAYER_BACK).get() - digitalChannels.at(PLAYER_FORWARD).get();
+	return movement;
+}
+
+bool InputManager::isActionDigital(const int &act) {
+	switch(act) {
+	case PLAYER_JUMP:
+	case PLAYER_PORTAL_0:
+	case PLAYER_PORTAL_1:
+	case PLAYER_FORWARD:
+	case PLAYER_BACK:
+	case PLAYER_LEFT:
+	case PLAYER_RIGHT :
+	case GAME_PAUSE :
+	case GAME_QUIT : {
+		return true;
+		break;
+	}
+	case PLAYER_MOVE_ANALOGUE:
+	case PLAYER_LOOK_ANALOGUE:
+	case ACTION_MAX :
+	case ACTION_INVALID :
+	default : {
+		return false;
+		break;
+	}
+	}
+}
+
+}

--- a/source/input/InputSource.cpp
+++ b/source/input/InputSource.cpp
@@ -1,5 +1,8 @@
 #include <radix/input/InputSource.hpp>
 
+#include <SDL2/SDL_keyboard.h>
+#include <SDL2/SDL_gamecontroller.h>
+
 #include <algorithm>
 
 #include <radix/core/event/EventDispatcher.hpp>
@@ -8,10 +11,82 @@ using namespace std;
 
 namespace radix {
 
+const InputSource::LookUpTable InputSource::mouseButtonLookUp = {
+  {"mouse_button_left",   (int)MouseButton::Left},
+  {"mouse_button_middle", (int)MouseButton::Middle},
+  {"mouse_button_right",  (int)MouseButton::Right},
+  {"mouse_button_aux_1",  (int)MouseButton::Aux1},
+  {"mouse_button_aux_2",  (int)MouseButton::Aux2},
+  {"mouse_button_aux_3",  (int)MouseButton::Aux3},
+  {"mouse_button_aux_4",  (int)MouseButton::Aux4},
+  {"mouse_button_aux_5",  (int)MouseButton::Aux5},
+  {"mouse_button_aux_6",  (int)MouseButton::Aux6}
+};
+
+const InputSource::LookUpTable InputSource::controllerButtonLookUp = {
+  {"button_a",        (int)SDL_CONTROLLER_BUTTON_A},
+  {"button_b",        (int)SDL_CONTROLLER_BUTTON_B},
+  {"button_x",        (int)SDL_CONTROLLER_BUTTON_X},
+  {"button_y",        (int)SDL_CONTROLLER_BUTTON_Y},
+  {"button_back",     (int)SDL_CONTROLLER_BUTTON_BACK},
+  {"button_guide",    (int)SDL_CONTROLLER_BUTTON_GUIDE},
+  {"button_start",    (int)SDL_CONTROLLER_BUTTON_START},
+  {"left_stick",      (int)SDL_CONTROLLER_BUTTON_LEFTSTICK},
+  {"right_stick",     (int)SDL_CONTROLLER_BUTTON_RIGHTSTICK},
+  {"left_shoulder",   (int)SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
+  {"right_shoulder",  (int)SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
+  {"dpad_up",         (int)SDL_CONTROLLER_BUTTON_DPAD_UP},
+  {"dpad_down",       (int)SDL_CONTROLLER_BUTTON_DPAD_DOWN},
+  {"dpad_left",       (int)SDL_CONTROLLER_BUTTON_DPAD_LEFT},
+  {"dpad_right",      (int)SDL_CONTROLLER_BUTTON_DPAD_RIGHT}
+};
+
 void InputSource::removeDispatcher(EventDispatcher &d) {
   dispatchers.erase(std::remove_if(dispatchers.begin(), dispatchers.end(), [&d](EventDispatcher &e) {
     return std::addressof(e) == std::addressof(d);
   }), dispatchers.end());
+}
+
+int InputSource::keyboardGetKeyFromString(const std::string &key) {
+	return (int)SDL_GetScancodeFromName(key.c_str());
+}
+
+int InputSource::mouseGetButtonFromString(const std::string &buttonStr) {
+  LookUpTable::const_iterator button = mouseButtonLookUp.find(buttonStr);
+  if (button != mouseButtonLookUp.end()) {
+    return button->second;
+  } else {
+    return -1;
+  }
+}
+
+int InputSource::gameControllerGetButtonFromString(const std::string &buttonStr) {
+  LookUpTable::const_iterator button = controllerButtonLookUp.find(buttonStr);
+  if (button != controllerButtonLookUp.end()) {
+    return button->second;
+  } else {
+    return -1;
+  }
+}
+
+int InputSource::gameControllerGetAxisFromString(const std::string &axisStr) {
+  if (axisStr == "stick_left") {
+    return 0;
+  } else if (axisStr == "stick_right") {
+    return 1;
+  } else {
+    return -1;
+  }
+}
+
+int InputSource::gameControllerGetTriggerFromString(const std::string &triggerStr) {
+  if (triggerStr == "trigger_left") {
+    return 0;
+  } else if (triggerStr == "trigger_right") {
+    return 1;
+  } else {
+    return -1;
+  }
 }
 
 } /* namespace radix */


### PR DESCRIPTION
- Created ChannelBase and ChannelListener classes.
- Created Channel and SubChannel classes.
- Mouse axis events are no longer separated into x and y axes and have Vector2f (i.e. MouseAxisEvent has information for both axes)
- Controller axis events are no longer separated into left_stick_x, left_stick_y, right_stick_x, etc. but are now events that have all the information for one stick (i.e. a ControllerAxisEvent has information for both left_stick_x and left_stick_y).
- Controller trigger events are now treated separately to stick events.

Each action is now represented by a Channel. Each Channel manages one or more SubChannels which correspond to a particular raw input. The SubChannels add observers to the event dispatcher so do not need to be updated in any way. Channels have listeners which they notify upon a change in the Channel value. 

The input manager class has been changed so it actually manages the input as opposed to just containing all the input information, as it was previously. That is InputManager keeps a reference to BaseGame and calls BaseGame::close() as opposed to BaseGame querying InputManager every frame and asking if it should close itself.