### PR TITLE
Updated header file inclusions

### DIFF
--- a/source/core/diag/LogInput.cpp
+++ b/source/core/diag/LogInput.cpp
@@ -1,7 +1,7 @@
 #include <radix/core/diag/LogInput.hpp>
 
 #include <iomanip>
-#include <sstream>
+#include <iostream>
 #include <string>
 
 #include <radix/core/math/Vector2f.hpp>


### PR DESCRIPTION
Since we are using an ostream it makes sense to include the 'iostream' header. The 'sstream' is needed only if stringstreams are used