### PR TITLE
Add link for irc.freenode.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Henry Hirsch, Julian Thijssen, Dorian Wouters, Geert Custers [all contributors](
 For instructions on how to compile the game engine please [read COMPILE.md](COMPILE.md).
 
 ## Join the team
-Chat with us at irc.freenode.org in the channel [#glportal](http://webchat.freenode.net/?channels=%23glportal&uio=d4)
+Chat with us at [irc.freenode.org](irc.freenode.org) in the channel [#glportal](http://webchat.freenode.net/?channels=%23glportal&uio=d4)
 for questions and discussions about the development of the game.
 Report Issues to [github](https://github.com/GlPortal/RadixEngine/issues).
 


### PR DESCRIPTION
Added a link rather than just merely text for "Join the team" section when clicking on irc.freenode.org