### PR TITLE
added stdexcept header in XmlScreenLoader.cpp

### DIFF
--- a/source/data/screen/XmlScreenLoader.cpp
+++ b/source/data/screen/XmlScreenLoader.cpp
@@ -1,6 +1,6 @@
 #include <radix/data/screen/XmlScreenLoader.hpp>
 #include <radix/env/Util.hpp>
-
+#include <stdexcept>
 using namespace tinyxml2;
 
 namespace radix {


### PR DESCRIPTION
std::runtime_error was being used without the required header file